### PR TITLE
fix: dependabot templated pyproject

### DIFF
--- a/{{cookiecutter.package_name}}/pyproject.toml
+++ b/{{cookiecutter.package_name}}/pyproject.toml
@@ -12,7 +12,6 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = "^{{ cookiecutter.python_version }}"
 structlog = "^21.1.0"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
- removed templated declared python dependency in generated pyproject.toml (dependabot has no idea what version a templated string is)