### PR TITLE
feat: refactor test architecture to decouple coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,6 @@ target/
 
 # direnv
 .direnv/
+
+# claude
+.claude

--- a/Justfile
+++ b/Justfile
@@ -48,9 +48,6 @@ clean: clean-docs clean-build clean-pyc clean-test
 # Check code coverage with current Python
 coverage:
     just tox run -e coverage
-    {{runner_cmd}} run coverage report -m
-    {{runner_cmd}} run coverage html
-    open htmlcov/index.html
 
 # Generate Sphinx documentation (tox:docs)
 [no-quiet]

--- a/Justfile
+++ b/Justfile
@@ -47,7 +47,7 @@ clean: clean-docs clean-build clean-pyc clean-test
 
 # Check code coverage with current Python
 coverage:
-    {{runner_cmd}} run pytest --cov --cov-config=pyproject.toml --cov-append --cov-report term-missing --doctest-modules -ra -q -n auto
+    just tox run -e coverage
     {{runner_cmd}} run coverage report -m
     {{runner_cmd}} run coverage html
     open htmlcov/index.html

--- a/tox.ini
+++ b/tox.ini
@@ -22,14 +22,27 @@ allowlist_externals =
 commands_pre =
     uv sync --python {env_python} --locked
 commands =
-    pytest --cov --cov-config=pyproject.toml --cov-append --cov-report term-missing --doctest-modules --cov-report xml:{toxworkdir}/.coverage.{envname}.xml -ra -q -n auto {posargs}
+    pytest --doctest-modules --tb=short --numprocesses=auto --strict-markers -ra {posargs}
+set_env =
+    PIP_DISABLE_VERSION_CHECK = 1
+    UV_PROJECT_ENVIRONMENT={envdir}
+depends =
+    py3{10,11}: clean
+
+[testenv:coverage]
+skip_install = true
+parallel_show_output = true
+allowlist_externals =
+    uv
+commands_pre =
+    uv sync --python {env_python} --locked
+commands =
+    pytest --cov --cov-config=pyproject.toml --cov-append --cov-report=term-missing --cov-report=xml:{toxworkdir}/.coverage.{envname}.xml --doctest-modules --tb=short --numprocesses=auto --strict-markers -ra {posargs}
     coverage xml -o {toxworkdir}/.coverage.{envname}.xml
 set_env =
     PIP_DISABLE_VERSION_CHECK = 1
     UV_PROJECT_ENVIRONMENT={envdir}
     COVERAGE_FILE={toxworkdir}/.coverage.{envname}
-depends =
-    py3{10,11}: clean
 
 [testenv:pre-commit]
 skip_install = true

--- a/{{cookiecutter.package_name}}/Justfile
+++ b/{{cookiecutter.package_name}}/Justfile
@@ -43,7 +43,7 @@ clean: clean-docs clean-build clean-pyc clean-test
 
 # Check code coverage with current Python
 coverage:
-    {{ "{{" }}runner_cmd{{ "}}" }} run pytest --cov --cov-config=pyproject.toml --cov-append --cov-report term-missing --doctest-modules -ra -q -n auto
+    just tox run -e coverage
     {{ "{{" }}runner_cmd{{ "}}" }} run coverage report -m
     {{ "{{" }}runner_cmd{{ "}}" }} run coverage html
     open htmlcov/index.html

--- a/{{cookiecutter.package_name}}/Justfile
+++ b/{{cookiecutter.package_name}}/Justfile
@@ -44,9 +44,6 @@ clean: clean-docs clean-build clean-pyc clean-test
 # Check code coverage with current Python
 coverage:
     just tox run -e coverage
-    {{ "{{" }}runner_cmd{{ "}}" }} run coverage report -m
-    {{ "{{" }}runner_cmd{{ "}}" }} run coverage html
-    open htmlcov/index.html
 
 # Generate Sphinx documentation (tox:docs)
 [no-quiet]

--- a/{{cookiecutter.package_name}}/tox.ini
+++ b/{{cookiecutter.package_name}}/tox.ini
@@ -25,16 +25,29 @@ allowlist_externals =
 commands_pre =
     uv sync --python {env_python} --locked
 commands =
-    pytest --cov --cov-config=pyproject.toml --cov-append --cov-report term-missing --doctest-modules --cov-report xml:{toxworkdir}/.coverage.{envname}.xml -ra -q -n auto {posargs}
+    pytest --doctest-modules --tb=short --numprocesses=auto --strict-markers -ra {posargs}
+set_env =
+    PIP_DISABLE_VERSION_CHECK = 1
+    UV_PROJECT_ENVIRONMENT={envdir}
+depends =
+{%- for python_version in cookiecutter.supported_python_versions.split(',') %}
+    py{{ python_version|trim|replace('.','') }}: clean
+{%- endfor %}
+
+[testenv:coverage]
+skip_install = true
+parallel_show_output = true
+allowlist_externals =
+    uv
+commands_pre =
+    uv sync --python {env_python} --locked
+commands =
+    pytest --cov --cov-config=pyproject.toml --cov-append --cov-report=term-missing --cov-report=xml:{toxworkdir}/.coverage.{envname}.xml --doctest-modules --tb=short --numprocesses=auto --strict-markers -ra {posargs}
     coverage xml -o {toxworkdir}/.coverage.{envname}.xml
 set_env =
     PIP_DISABLE_VERSION_CHECK = 1
     UV_PROJECT_ENVIRONMENT={envdir}
     COVERAGE_FILE={toxworkdir}/.coverage.{envname}
-depends =
-{%- for python_version in cookiecutter.supported_python_versions.split(',') %}
-    py{{ python_version|trim|replace('.','') }}: clean
-{%- endfor %}
 
 [testenv:pre-commit]
 skip_install =


### PR DESCRIPTION
Summary:
  - Decoupled coverage from default [testenv] in both main project and cookiecutter template
  - Created dedicated [testenv:coverage] environments for coverage analysis
  - Updated `just tests` to accept arguments via {posargs} for flexible test execution
  - Removed redundant `just test` command in favor of unified tests command
  - Simplified coverage command to use dedicated tox environment
  - Improved pytest flags for better readability and debugging (--tb=short, --strict-markers, etc.)

Closes: #536 