### PR TITLE
fix(template): correct sphinxawesome-theme package name typo

### DIFF
--- a/tests/test_cookiecutter_generation.py
+++ b/tests/test_cookiecutter_generation.py
@@ -840,5 +840,46 @@ def test_with_python_version(
                     )
 
 
+THIRD_PARTY_SPHINX_THEMES = [
+    'furo',
+    'sphinx-rtd-theme',
+    'sphinx-book-theme',
+    'pydata-sphinx-theme',
+    'sphinx-press-theme',
+    'piccolo-theme',
+    'sphinxawesome-theme',
+    'sphinx-wagtail-theme',
+]
+
+
+@pytest.mark.parametrize('sphinx_theme', THIRD_PARTY_SPHINX_THEMES)
+def test_with_sphinx_theme(
+    cookies: Cookies,
+    default_context: dict[str, str],
+    sphinx_theme: str,
+) -> None:
+    """Verify generated pyproject.toml has correct sphinx theme package."""
+    default_context['sphinx_theme'] = sphinx_theme
+    baked_project = cookies.bake(extra_context=default_context)
+
+    assert baked_project.exit_code == 0
+    assert baked_project.exception is None
+    assert baked_project.project_path
+    assert baked_project.project_path.is_dir()
+
+    abs_baked_files = build_files_list(str(baked_project.project_path))
+
+    for path in abs_baked_files:
+        if 'pyproject.toml' in path:
+            with (
+                Path(path).open('rb', 0) as file,
+                mmap.mmap(file.fileno(), 0, access=mmap.ACCESS_READ) as s,
+            ):
+                if s.find(sphinx_theme.encode()) == -1:
+                    pytest.fail(
+                        f'pyproject.toml should contain {sphinx_theme}'
+                    )
+
+
 # vim: fenc=utf-8
 # vim: filetype=python

--- a/{{cookiecutter.package_name}}/pyproject.toml
+++ b/{{cookiecutter.package_name}}/pyproject.toml
@@ -54,7 +54,7 @@ docs = [
     {% elif cookiecutter.sphinx_theme == "piccolo-theme" %}
     "piccolo-theme>=0.22.0,<1",
     {% elif cookiecutter.sphinx_theme == "sphinxawesome-theme" %}
-    "spinxawesome-theme>=5.1.6,<6",
+    "sphinxawesome-theme>=5.1.6,<6",
     {% elif cookiecutter.sphinx_theme == "sphinx-wagtail-theme" %}
     "sphinx-wagtail-theme>=6.3.0,<7",
     {% endif %}


### PR DESCRIPTION
## Summary
- Fix typo in `{{cookiecutter.package_name}}/pyproject.toml`: `spinxawesome-theme` → `sphinxawesome-theme` (missing 'h')
- Bug was introduced in #505 (uv migration, May 2025) during conversion from Poetry-style to pip-style dependency syntax
- Users selecting the `sphinxawesome-theme` option got a broken install due to the misspelled package name
- Add parameterized `test_with_sphinx_theme` covering all 8 third-party sphinx themes to prevent regressions

## Test plan
- [x] All 102 tests pass (94 existing + 8 new sphinx theme tests)
- [x] Verified test catches the typo (fails with `spinxawesome-theme`, passes with `sphinxawesome-theme`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)