### PR TITLE
refactor: replace black and isort with ruff format and ruff isort rules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,22 +26,8 @@ repos:
     - id: ruff
       stages: [manual]
       args: ['--config', 'pyproject.toml', '--fix', '--exit-non-zero-on-fix']
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.10.0
-    hooks:
-      - id: black
-        args: ['--config', 'pyproject.toml']
-        exclude: |
-          (?x)(\{\{cookiecutter\.package_name\}\}\/[docs|tests])
-  - repo: https://github.com/asottile/blacken-docs
-    rev: 1.19.1
-    hooks:
-      - id: blacken-docs
-        additional_dependencies: [black==24.10.0]
-  - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
+    - id: ruff-format
+      args: ['--config', 'pyproject.toml']
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0
     hooks:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ This is a modern Python Cookiecutter template project that generates standardize
 - **Configuration**: `cookiecutter.json` defines template variables, defaults, and choices (like sphinx theme options)
 
 ### Critical Architectural Patterns
-- **Template exclusions**: `pyproject.toml` excludes `{{cookiecutter.package_name}}/` from mypy/black/ruff to prevent linting unrendered Jinja2 templates
+- **Template exclusions**: `pyproject.toml` excludes `{{cookiecutter.package_name}}/` from mypy/ruff to prevent linting unrendered Jinja2 templates
 - **Post-generation hooks**: `hooks/post_gen_project.py` conditionally removes files based on user selections (e.g., direnv, author files, Dependabot workflows). Note: `publish.yml` is never removed when GitHub Actions is enabled - it always builds and uploads artifacts to GitHub Actions even when all publish destinations are disabled.
 - **Test strategy**: Uses `pytest-cookies` plugin to test actual template generation, verifying that cookiecutter variables are properly substituted and expected files exist
 

--- a/README.md
+++ b/README.md
@@ -52,10 +52,7 @@ template is the tool that will help you do just that.
 - [`pre-commit`](https://pre-commit.com) hooks with comprehensive tooling:
   - [`uv-lock`](https://github.com/astral-sh/uv-pre-commit) for dependency management
   - [`mypy`](https://mypy-lang.org) for type checking
-  - [`ruff`](https://github.com/astral-sh/ruff) for linting and formatting
-  - [`black`](https://github.com/psf/black) for code formatting
-  - [`blacken-docs`](https://github.com/adamchainz/blacken-docs) for formatting code in docs
-  - [`isort`](https://github.com/pycqa/isort) for import sorting
+  - [`ruff`](https://github.com/astral-sh/ruff) for linting, formatting, and import sorting
   - [`bashate`](https://github.com/openstack/bashate) for shell script linting
   - [`commitlint`](https://github.com/conventional-changelog/commitlint) for commit message standards
   - [`detect-secrets`](https://github.com/Yelp/detect-secrets) for secret detection

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ Repository = "https://github.com/ryankanno/cookiecutter-py"
 dev = [
     "pytest>=8.3.5,<10",
     "pytest-cookies>=0.7.0,<0.8",
-    "black>=25.1.0,<27",
     "tox>=4.25.0,<5",
     "tox-uv>=1.21.5",
     "mypy>=1.15.0,<2",
@@ -90,36 +89,6 @@ exclude = [
     'cookiecutter\.package_name',
 ]
 
-[tool.black]
-line-length = 79
-skip-string-normalization = true
-target-version = ['py311', 'py312', 'py313']
-include = '\.pyi?$'
-exclude = '''
-(
-  /(
-     \.ruff_cache
-     | \.direnv
-     | \.eggs
-     | \.git
-     | \.hg
-     | \.mypy_cache
-     | \.nox
-     | \.tox
-     | \.venv
-     | venv
-     | \.svn
-     | _build
-     | buck-out
-     | build
-     | dist
-     | __pypackages__
-     | \{\{cookiecutter\.package_name\}\}\/docs
-     | \{\{cookiecutter\.package_name\}\}\/tests
- )/
-)
-'''
-
 [tool.pytest.ini_options]
 minversion = "7.4"
 addopts = "-n auto"
@@ -150,19 +119,6 @@ exclude_lines = [
 show_missing = true
 skip_covered = false
 
-[tool.isort]
-force_grid_wrap = 0
-force_single_line = true
-include_trailing_comma = true
-lines_after_imports = 2
-multi_line_output = 3
-use_parentheses = true
-known_third_party = [""]
-default_section = "THIRDPARTY"
-known_first_party = "{{ cookiecutter.package_name }}"
-sections = "FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER"
-skip = "tests"
-
 [tool.ruff]
 extend-exclude = ['[{][{]cookiecutter.package_name[}][}]/tests', '[{][{]cookiecutter.package_name[}][}]/docs', 'docs']
 line-length = 79
@@ -192,6 +148,7 @@ select = [
     "FIX",  # temporary developer notes (flake8-fixme)
     "FURB", # code improvements (refurb)
     "G",    # logging string formatting (flake8-logging-format)
+    "I",    # import sorting (isort)
     "LOG",  # logging module usage (flake8-logging)
     "PERF", # performance anti-patterns (perflint)
     "PGH",  # pygrep hooks
@@ -213,6 +170,13 @@ ignore = [
     "D103",
     "D104",
 ]
+
+[tool.ruff.format]
+quote-style = "preserve"
+
+[tool.ruff.lint.isort]
+force-single-line = true
+lines-after-imports = 2
 
 [tool.ruff.lint.per-file-ignores]
 "tests/test_*.py" = ["S101"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,6 +172,7 @@ ignore = [
 ]
 
 [tool.ruff.format]
+preview = true
 quote-style = "preserve"
 
 [tool.ruff.lint.isort]

--- a/tests/test_cookiecutter_generation.py
+++ b/tests/test_cookiecutter_generation.py
@@ -121,9 +121,9 @@ def check_paths_substitution(paths: list[str]) -> None:
         with Path(path).open(encoding="utf-8") as f:
             line = f.readline()
             match = RE_OBJ.search(line)
-            assert (
-                match is None
-            ), f"cookiecutter variable not replaced in {path}"
+            assert match is None, (
+                f"cookiecutter variable not replaced in {path}"
+            )
 
 
 def check_paths_exist(
@@ -604,9 +604,9 @@ def test_dockerfile_structure(
 
     # Verify no unrendered cookiecutter variables
     for i, line in enumerate(lines, 1):
-        assert (
-            RE_OBJ.search(line) is None
-        ), f'Unrendered cookiecutter variable on line {i}: {line}'
+        assert RE_OBJ.search(line) is None, (
+            f'Unrendered cookiecutter variable on line {i}: {line}'
+        )
 
     # Verify multi-stage build has required stages
     stage_names = parse_dockerfile_stages(lines)
@@ -617,9 +617,9 @@ def test_dockerfile_structure(
         'project-builder',
         'final',
     ]:
-        assert (
-            expected_stage in stage_names
-        ), f'Missing expected stage: {expected_stage}'
+        assert expected_stage in stage_names, (
+            f'Missing expected stage: {expected_stage}'
+        )
 
     # Verify COPY --from references point to defined stages
     defined_sources = set(stage_names) | {'uv-source'}
@@ -627,9 +627,9 @@ def test_dockerfile_structure(
         if 'COPY --from=' not in line:
             continue
         from_ref = line.split('--from=')[1].split()[0]
-        assert (
-            from_ref in defined_sources
-        ), f'COPY --from={from_ref} references undefined stage'
+        assert from_ref in defined_sources, (
+            f'COPY --from={from_ref} references undefined stage'
+        )
 
     # Verify final stage runs as non-root user
     final_lines = get_stage_lines(lines, 'final')

--- a/tests/test_cookiecutter_generation.py
+++ b/tests/test_cookiecutter_generation.py
@@ -17,10 +17,12 @@ import pytest
 from binaryornot.check import is_binary
 from pytest_cookies.plugin import Cookies
 
+
 # Add hooks directory to path to import from hook files
 sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 from pre_gen_project import strtobool  # noqa: E402
+
 
 LOGGER = logging.getLogger(__name__)
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -12,10 +12,8 @@ from pathlib import Path
 import pytest
 
 from hooks.post_gen_project import remove_path
-from hooks.pre_gen_project import (
-    validate_dependabot,
-    validate_supported_python_versions,
-)
+from hooks.pre_gen_project import validate_dependabot
+from hooks.pre_gen_project import validate_supported_python_versions
 
 
 def test_remove_path() -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 import pytest
 
+
 # Add hooks directory to path to import from hook files
 sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10, <3.14"
 
 [[package]]
@@ -70,40 +70,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a7/fe/7ebfec74d49f97fc55cd38240c7a7d08134002b1e14be8c3897c0dd5e49b/binaryornot-0.4.4.tar.gz", hash = "sha256:359501dfc9d40632edc9fac890e19542db1a287bbcfa58175b66658392018061", size = 371054, upload-time = "2017-08-03T15:55:25.08Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/24/7e/f7b6f453e6481d1e233540262ccbfcf89adcd43606f44a028d7f5fae5eb2/binaryornot-0.4.4-py2.py3-none-any.whl", hash = "sha256:b8b71173c917bddcd2c16070412e369c3ed7f0528926f70cac18a6c97fd563e4", size = 9006, upload-time = "2017-08-03T15:55:31.23Z" },
-]
-
-[[package]]
-name = "black"
-version = "25.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "mypy-extensions" },
-    { name = "packaging" },
-    { name = "pathspec" },
-    { name = "platformdirs" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/94/49/26a7b0f3f35da4b5a65f081943b7bcd22d7002f5f0fb8098ec1ff21cb6ef/black-25.1.0.tar.gz", hash = "sha256:33496d5cd1222ad73391352b4ae8da15253c5de89b93a80b3e2c8d9a19ec2666", size = 649449, upload-time = "2025-01-29T04:15:40.373Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/3b/4ba3f93ac8d90410423fdd31d7541ada9bcee1df32fb90d26de41ed40e1d/black-25.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:759e7ec1e050a15f89b770cefbf91ebee8917aac5c20483bc2d80a6c3a04df32", size = 1629419, upload-time = "2025-01-29T05:37:06.642Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/02/0bde0485146a8a5e694daed47561785e8b77a0466ccc1f3e485d5ef2925e/black-25.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0e519ecf93120f34243e6b0054db49c00a35f84f195d5bce7e9f5cfc578fc2da", size = 1461080, upload-time = "2025-01-29T05:37:09.321Z" },
-    { url = "https://files.pythonhosted.org/packages/52/0e/abdf75183c830eaca7589144ff96d49bce73d7ec6ad12ef62185cc0f79a2/black-25.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:055e59b198df7ac0b7efca5ad7ff2516bca343276c466be72eb04a3bcc1f82d7", size = 1766886, upload-time = "2025-01-29T04:18:24.432Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/a6/97d8bb65b1d8a41f8a6736222ba0a334db7b7b77b8023ab4568288f23973/black-25.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:db8ea9917d6f8fc62abd90d944920d95e73c83a5ee3383493e35d271aca872e9", size = 1419404, upload-time = "2025-01-29T04:19:04.296Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/4f/87f596aca05c3ce5b94b8663dbfe242a12843caaa82dd3f85f1ffdc3f177/black-25.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a39337598244de4bae26475f77dda852ea00a93bd4c728e09eacd827ec929df0", size = 1614372, upload-time = "2025-01-29T05:37:11.71Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/d0/2c34c36190b741c59c901e56ab7f6e54dad8df05a6272a9747ecef7c6036/black-25.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:96c1c7cd856bba8e20094e36e0f948718dc688dba4a9d78c3adde52b9e6c2299", size = 1442865, upload-time = "2025-01-29T05:37:14.309Z" },
-    { url = "https://files.pythonhosted.org/packages/21/d4/7518c72262468430ead45cf22bd86c883a6448b9eb43672765d69a8f1248/black-25.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bce2e264d59c91e52d8000d507eb20a9aca4a778731a08cfff7e5ac4a4bb7096", size = 1749699, upload-time = "2025-01-29T04:18:17.688Z" },
-    { url = "https://files.pythonhosted.org/packages/58/db/4f5beb989b547f79096e035c4981ceb36ac2b552d0ac5f2620e941501c99/black-25.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:172b1dbff09f86ce6f4eb8edf9dede08b1fce58ba194c87d7a4f1a5aa2f5b3c2", size = 1428028, upload-time = "2025-01-29T04:18:51.711Z" },
-    { url = "https://files.pythonhosted.org/packages/83/71/3fe4741df7adf015ad8dfa082dd36c94ca86bb21f25608eb247b4afb15b2/black-25.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4b60580e829091e6f9238c848ea6750efed72140b91b048770b64e74fe04908b", size = 1650988, upload-time = "2025-01-29T05:37:16.707Z" },
-    { url = "https://files.pythonhosted.org/packages/13/f3/89aac8a83d73937ccd39bbe8fc6ac8860c11cfa0af5b1c96d081facac844/black-25.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1e2978f6df243b155ef5fa7e558a43037c3079093ed5d10fd84c43900f2d8ecc", size = 1453985, upload-time = "2025-01-29T05:37:18.273Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/22/b99efca33f1f3a1d2552c714b1e1b5ae92efac6c43e790ad539a163d1754/black-25.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b48735872ec535027d979e8dcb20bf4f70b5ac75a8ea99f127c106a7d7aba9f", size = 1783816, upload-time = "2025-01-29T04:18:33.823Z" },
-    { url = "https://files.pythonhosted.org/packages/18/7e/a27c3ad3822b6f2e0e00d63d58ff6299a99a5b3aee69fa77cd4b0076b261/black-25.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:ea0213189960bda9cf99be5b8c8ce66bb054af5e9e861249cd23471bd7b0b3ba", size = 1440860, upload-time = "2025-01-29T04:19:12.944Z" },
-    { url = "https://files.pythonhosted.org/packages/98/87/0edf98916640efa5d0696e1abb0a8357b52e69e82322628f25bf14d263d1/black-25.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8f0b18a02996a836cc9c9c78e5babec10930862827b1b724ddfe98ccf2f2fe4f", size = 1650673, upload-time = "2025-01-29T05:37:20.574Z" },
-    { url = "https://files.pythonhosted.org/packages/52/e5/f7bf17207cf87fa6e9b676576749c6b6ed0d70f179a3d812c997870291c3/black-25.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:afebb7098bfbc70037a053b91ae8437c3857482d3a690fefc03e9ff7aa9a5fd3", size = 1453190, upload-time = "2025-01-29T05:37:22.106Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/ee/adda3d46d4a9120772fae6de454c8495603c37c4c3b9c60f25b1ab6401fe/black-25.1.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:030b9759066a4ee5e5aca28c3c77f9c64789cdd4de8ac1df642c40b708be6171", size = 1782926, upload-time = "2025-01-29T04:18:58.564Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/64/94eb5f45dcb997d2082f097a3944cfc7fe87e071907f677e80788a2d7b7a/black-25.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:a22f402b410566e2d1c950708c77ebf5ebd5d0d88a6a2e87c86d9fb48afa0d18", size = 1442613, upload-time = "2025-01-29T04:19:27.63Z" },
-    { url = "https://files.pythonhosted.org/packages/09/71/54e999902aed72baf26bca0d50781b01838251a462612966e9fc4891eadd/black-25.1.0-py3-none-any.whl", hash = "sha256:95e8176dae143ba9097f351d174fdaf0ccd29efb414b362ae3fd72bf0f710717", size = 207646, upload-time = "2025-01-29T04:15:38.082Z" },
 ]
 
 [[package]]
@@ -262,7 +228,6 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "black" },
     { name = "deptry" },
     { name = "mypy" },
     { name = "pdbp" },
@@ -290,7 +255,6 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "black", specifier = ">=25.1.0,<27" },
     { name = "deptry", specifier = ">=0.23.0,<0.26" },
     { name = "mypy", specifier = ">=1.15.0,<2" },
     { name = "pdbp", specifier = ">=1.7.1,<2" },
@@ -709,15 +673,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
-]
-
-[[package]]
-name = "pathspec"
-version = "0.12.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043, upload-time = "2023-12-10T22:30:45Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191, upload-time = "2023-12-10T22:30:43.14Z" },
 ]
 
 [[package]]

--- a/{{cookiecutter.package_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.package_name}}/.pre-commit-config.yaml
@@ -24,21 +24,8 @@ repos:
     - id: ruff
       args: ['--config', 'pyproject.toml', '--fix', '--exit-non-zero-on-fix']
       stages: [manual]
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.10.0
-    hooks:
-      - id: black
-        args: [--safe, --quiet]
-        language_version: python{{cookiecutter.python_version}}
-  - repo: https://github.com/adamchainz/blacken-docs
-    rev: 1.19.1
-    hooks:
-      - id: blacken-docs
-        additional_dependencies: [black==24.10.0]
-  - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
+    - id: ruff-format
+      args: ['--config', 'pyproject.toml']
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0
     hooks:

--- a/{{cookiecutter.package_name}}/pyproject.toml
+++ b/{{cookiecutter.package_name}}/pyproject.toml
@@ -165,6 +165,7 @@ ignore = [
 ]
 
 [tool.ruff.format]
+preview = true
 quote-style = "preserve"
 
 [tool.ruff.lint.isort]

--- a/{{cookiecutter.package_name}}/pyproject.toml
+++ b/{{cookiecutter.package_name}}/pyproject.toml
@@ -31,7 +31,6 @@ dev = [
     "pytest-randomly>=3.16.0,<4",
     "pytest-xdist>=3.6.1,<4",
     "tox>={{ cookiecutter.tox_version }}",
-    "black>=24.10.0,<25",
     "hypothesis>=6.115.5,<7",
     "mutmut>=3.2.0,<4",
     "ruff>=0.7.1,<0.8",
@@ -88,34 +87,6 @@ warn_return_any = true
 warn_unused_configs = true
 warn_unused_ignores = false
 
-[tool.black]
-line-length = 79
-skip-string-normalization = true
-target-version = ['py{{ cookiecutter.python_version|replace(".", "") }}']
-include = '\.pyi?$'
-exclude = '''
-(
-  /(
-      \.direnv
-     | \.eggs
-     | \.git
-     | \.hg
-     | \.mypy_cache
-     | \.nox
-     | \.tox
-     | \.venv
-     | venv
-     | \.svn
-     | _build
-     | buck-out
-     | build
-     | dist
-     | __pypackages__
-     | tests
- )/
-)
-'''
-
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = "-ra -q -n auto"
@@ -141,18 +112,6 @@ exclude_lines = [
 ]
 show_missing = true
 skip_covered = false
-
-[tool.isort]
-force_grid_wrap = 0
-force_single_line = true
-include_trailing_comma = true
-lines_after_imports = 2
-multi_line_output = 3
-use_parentheses = true
-known_third_party = []
-default_section = "THIRDPARTY"
-known_first_party = "{{ cookiecutter.package_name }}"
-sections = "FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER"
 
 [tool.ruff]
 line-length = 79
@@ -183,6 +142,7 @@ select = [
     "FIX",  # temporary developer notes (flake8-fixme)
     "FURB", # code improvements (refurb)
     "G",    # logging string formatting (flake8-logging-format)
+    "I",    # import sorting (isort)
     "LOG",  # logging module usage (flake8-logging)
     "PERF", # performance anti-patterns (perflint)
     "PGH",  # pygrep hooks
@@ -203,6 +163,14 @@ ignore = [
     "D103",
     "D104",
 ]
+
+[tool.ruff.format]
+quote-style = "preserve"
+
+[tool.ruff.lint.isort]
+force-single-line = true
+lines-after-imports = 2
+known-first-party = ["{{ cookiecutter.package_name }}"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/test_*.py" = ["S101"]


### PR DESCRIPTION
## Summary
- Drop `black`, `blacken-docs`, and `isort` in favor of ruff's built-in formatter and import sorting (`I` rules)
- Ruff already handles linting in this project, so this eliminates three redundant dependencies and their configuration
- Net result: **171 lines deleted**, 29 added

### Changes across both root project and template:
- Remove `black` and `isort` from dev dependencies
- Remove `[tool.black]` and `[tool.isort]` config sections from pyproject.toml
- Replace `black`, `blacken-docs`, and `isort` pre-commit hooks with `ruff-format`
- Add `I` (isort) to ruff lint select rules
- Add `[tool.ruff.format]` with `quote-style = "preserve"` (matches black's `skip-string-normalization`
- Add  with  and  (matches previous isort config)
- Update README.md and CLAUDE.md references

## Test plan
- [x] All 157 tests pass
- [x]  passes on entire codebase
- [x]  passes (import sorting)
- [x] Verified generated template has no black/isort references and includes ruff-format hook
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)