### PR TITLE
fix(template): fix tox.ini pypy env names and coverage section syntax

### DIFF
--- a/{{cookiecutter.package_name}}/tox.ini
+++ b/{{cookiecutter.package_name}}/tox.ini
@@ -5,20 +5,37 @@ set_env =
   TEMP = {env_tmp_dir}
 envlist =
 {%- for python_version in cookiecutter.supported_python_versions.split(',') %}
-    py{{ python_version|trim|replace('.','') }},
+{%- set v = python_version|trim %}
+{%- if v.startswith('pypy') %}
+    {{ v|replace('.','') }},
+{%- else %}
+    py{{ v|replace('.','') }},
+{%- endif %}
 {%- endfor %}
 {%- for python_version in cookiecutter.supported_python_versions.split(',') %}
-    coverage-py{{ python_version|trim|replace('.','') }},
+{%- set v = python_version|trim %}
+{%- if v.startswith('pypy') %}
+    coverage-{{ v|replace('.','') }},
+{%- else %}
+    coverage-py{{ v|replace('.','') }},
+{%- endif %}
 {%- endfor %}
     pre-commit,
 labels =
-    tests = {%- for python_version in cookiecutter.supported_python_versions.split(',') %}py{{ python_version|trim|replace('.','') }},{%- endfor %}
-    coverage = {%- for python_version in cookiecutter.supported_python_versions.split(',') %}coverage-py{{ python_version|trim|replace('.','') }},{%- endfor %}
+    tests = {%- for python_version in cookiecutter.supported_python_versions.split(',') %}{%- set v = python_version|trim %}{% if v.startswith('pypy') %}{{ v|replace('.','') }}{% else %}py{{ v|replace('.','') }}{% endif %},{%- endfor %}
+
+    coverage = {%- for python_version in cookiecutter.supported_python_versions.split(',') %}{%- set v = python_version|trim %}{% if v.startswith('pypy') %}coverage-{{ v|replace('.','') }}{% else %}coverage-py{{ v|replace('.','') }}{% endif %},{%- endfor %}
+
 
 [gh]
 python =
 {%- for python_version in cookiecutter.supported_python_versions.split(',') %}
-    {{ python_version|trim }} = coverage-py{{ python_version|trim|replace('.','') }}
+{%- set v = python_version|trim %}
+{%- if v.startswith('pypy') %}
+    {{ v }} = coverage-{{ v|replace('.','') }}
+{%- else %}
+    {{ v }} = coverage-py{{ v|replace('.','') }}
+{%- endif %}
 {%- endfor %}
 
 [testenv]
@@ -35,10 +52,15 @@ set_env =
     UV_PROJECT_ENVIRONMENT={envdir}
 depends =
 {%- for python_version in cookiecutter.supported_python_versions.split(',') %}
-    py{{ python_version|trim|replace('.','') }}: clean
+{%- set v = python_version|trim %}
+{%- if v.startswith('pypy') %}
+    {{ v|replace('.','') }}: clean
+{%- else %}
+    py{{ v|replace('.','') }}: clean
+{%- endif %}
 {%- endfor %}
 
-[testenv:coverage-py{%- for python_version in cookiecutter.supported_python_versions.split(',') %}{{ python_version|trim|replace('.','') }},{%- endfor %}]
+[testenv:coverage-{{ '{' }}{%- for python_version in cookiecutter.supported_python_versions.split(',') %}{%- set v = python_version|trim %}{% if v.startswith('pypy') %}{{ v|replace('.','') }}{% else %}py{{ v|replace('.','') }}{% endif %}{% if not loop.last %},{% endif %}{%- endfor %}{{ '}' }}]
 skip_install = true
 parallel_show_output = true
 allowlist_externals =


### PR DESCRIPTION
## Summary
- Fix pypy environment names: `pypy3.10` now correctly renders as `pypy310` instead of `pypypy310` by conditionally omitting the `py` prefix when the version already starts with `pypy`
- Fix coverage testenv section header to use tox generative syntax with curly braces: `[testenv:coverage-{py310,py311,...}]` instead of the malformed `[testenv:coverage-py310,311,...]`

### Before
```ini
[testenv:coverage-py310,311,312,313,pypy310,pypy311,]
```
Env names in envlist: `pypypy310`, `pypypy311`

### After
```ini
[testenv:coverage-{py310,py311,py312,py313,pypy310,pypy311}]
```
Env names in envlist: `pypy310`, `pypy311`

## Test plan
- [x] All 157 tests pass
- [x] Verified generated tox.ini renders correct env names for both CPython and PyPy versions
- [x] Verified tox generative syntax with curly braces and no trailing comma

🤖 Generated with [Claude Code](https://claude.com/claude-code)