### PR TITLE
fix: drop --icon flags from toastify calls in watch recipe

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -84,4 +84,4 @@ tox *TOX_ARGS:
 
 # Runs watchexec
 watch *JUST_RECIPE:
-    watchexec -r -e py -- "just {{ JUST_RECIPE }} && toastify send '🚀 just {{ JUST_RECIPE }}' 'just {{ JUST_RECIPE }} was successful' --icon info || toastify send '❌ just {{ JUST_RECIPE }}' '{{ JUST_RECIPE }} failed' --icon error"
+    watchexec -r -e py -- "just {{ JUST_RECIPE }} && toastify send '🚀 just {{ JUST_RECIPE }}' 'just {{ JUST_RECIPE }} was successful' || toastify send '❌ just {{ JUST_RECIPE }}' '{{ JUST_RECIPE }} failed'"

--- a/{{cookiecutter.package_name}}/Justfile
+++ b/{{cookiecutter.package_name}}/Justfile
@@ -80,4 +80,4 @@ tox *TOX_ARGS:
 
 # Runs watchexec
 watch *JUST_RECIPE:
-    watchexec -r -e py -- "just {{ "{{" }}JUST_RECIPE{{ "}}" }} && toastify send '🚀 just {{ "{{" }}JUST_RECIPE{{ "}}" }}' 'just {{ "{{" }}JUST_RECIPE{{ "}}" }} was successful' --icon info || toastify send '❌ just {{ "{{" }}JUST_RECIPE{{ "}}" }}' 'just {{ "{{" }}JUST_RECIPE{{ "}}" }} failed' --icon error"
+    watchexec -r -e py -- "just {{ "{{" }}JUST_RECIPE{{ "}}" }} && toastify send '🚀 just {{ "{{" }}JUST_RECIPE{{ "}}" }}' 'just {{ "{{" }}JUST_RECIPE{{ "}}" }} was successful' || toastify send '❌ just {{ "{{" }}JUST_RECIPE{{ "}}" }}' 'just {{ "{{" }}JUST_RECIPE{{ "}}" }} failed'"


### PR DESCRIPTION
## Summary
- Remove `--icon info` and `--icon error` arguments from `toastify send` invocations in the `watch` recipe
- Applied to both the root `Justfile` and the generated template `{{cookiecutter.package_name}}/Justfile`

## Test plan
- [ ] Run `just watch tests` locally and confirm toastify notifications still fire on success/failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)