### PR TITLE
fix: restrict clean-build '*.egg' find to files only

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -15,7 +15,7 @@ clean-build:
     rm -fr dist/
     rm -fr .eggs/
     find . -name '*.egg-info' -exec rm -fr {} +
-    find . -name '*.egg' -exec rm -f {} +
+    find . -name '*.egg' -type f -exec rm -f {} +
 
 # Remove Python artifacts (.pyc, .pyo, __pycache__)
 [private]

--- a/{{cookiecutter.package_name}}/Justfile
+++ b/{{cookiecutter.package_name}}/Justfile
@@ -15,7 +15,7 @@ clean-build:
     rm -fr dist/
     rm -fr .eggs/
     find . -name '*.egg-info' -exec rm -fr {} +
-    find . -name '*.egg' -exec rm -fr {} +
+    find . -name '*.egg' -type f -exec rm -f {} +
 
 # Remove Python artifacts (.pyc, .pyo, __pycache__)
 [private]


### PR DESCRIPTION
## Summary
- Add `-type f` to `find . -name '*.egg' ...` in the root `Justfile` and the template `{{cookiecutter.package_name}}/Justfile`.
- Before: `find .` walks into `.venv/` and `.tox/` where pkg_resources ships unpacked `*.egg` *directories* as test fixtures (e.g. `my_test_package-1.0-py3.7.egg`).
  - Root recipe used `rm -f` and aborted with "cannot remove ...: Is a directory".
  - Template recipe used `rm -fr` and would silently recurse into venv-shipped egg dirs.
- After: the walk only matches files, so both recipes converge on `-type f -exec rm -f {} +`.

## Related latent issue (not fixed here)
- The preceding line `find . -name '*.egg-info' -exec rm -fr {} +` has the same walk-everywhere problem and will delete `*.egg-info/` metadata inside `.venv/` if present. Happy to address in a follow-up if you want the full scope.

## Test plan
- [ ] Reproduce original failure: in a checkout where `.tox/` or `.venv/` exists with pkg_resources installed, run `just clean` on `main` and observe the "Is a directory" error.
- [ ] On this branch, run `just clean` in the same state and confirm it completes.