### PR TITLE
fix: prune venv/tox/direnv/git/worktrees from *.egg-info find

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -14,7 +14,7 @@ clean-build:
     rm -fr build/
     rm -fr dist/
     rm -fr .eggs/
-    find . -name '*.egg-info' -exec rm -fr {} +
+    find . \( -path ./.venv -o -path ./.tox -o -path ./.direnv -o -path ./.git -o -path ./.worktrees \) -prune -o -name '*.egg-info' -exec rm -fr {} +
     find . -name '*.egg' -type f -exec rm -f {} +
 
 # Remove Python artifacts (.pyc, .pyo, __pycache__)


### PR DESCRIPTION
## Summary
Follow-up to #585. The same walk-everywhere problem was flagged in that PR's body on the preceding line.

`find . -name '*.egg-info' -exec rm -fr {} +` in the root `clean-build` recipe walks the whole tree including `.venv/` and `.tox/`. `.egg-info` directories inside those hold installed-package metadata (editable installs, dist-info, etc.); deleting them silently breaks the virtualenv.

This adds a prune expression so only project-owned `.egg-info` directories are removed.

## Verification
Tested the find expression against a fixture with `.venv/example.egg-info`, `.tox/env.egg-info`, `src/my_pkg.egg-info`, and `top.egg-info`. Output (with `-print`):

```
./top.egg-info
./src/my_pkg.egg-info
```

`.venv` and `.tox` entries pruned as expected.

## Scope
- Root `Justfile` only. Template `{{cookiecutter.package_name}}/Justfile` has the same bug and is left as a follow-up per request.
- `clean-pyc` also walks everywhere but targets regeneratable artifacts (`*.pyc`, `*.pyo`, `__pycache__`); not a correctness bug, just wasted I/O.

## Test plan
- [ ] In a checkout with `.venv/` present and an editable install producing `.egg-info`, run `just clean` and confirm the venv's `.egg-info` metadata is intact while the project's `.egg-info` is gone.
