### PR TITLE
fix: align ruff version to >=0.11.7 across template and root configs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
           (?x)(cookiecutter\.package_name)
         additional_dependencies: [pytest==7.1.2]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.3
+    rev: v0.11.7
     hooks:
     - id: ruff
       args: ['--config', 'pyproject.toml']

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -8,6 +8,9 @@ import logging
 import sys
 
 
+logger = logging.getLogger(__name__)
+
+
 def strtobool(val: str) -> int:
     """Convert a string representation of truth to 1 or 0.
 
@@ -42,7 +45,7 @@ def validate_supported_python_versions(supported_python_versions: str) -> None:
 
     for version in supported_python_versions_list:
         if not version.startswith(tuple(VALID_PYTHON_VERSION_PREFIXES)):
-            logging.error(
+            logger.error(
                 "ERROR: %s is not a valid supported Python version. "
                 "Supported are any Pythons that begin with the following prefixes: %s ",  # noqa: B950, E501
                 version,
@@ -57,12 +60,12 @@ def validate_dependabot(
     should_install_gh_actions: bool,
 ) -> None:
     if not should_install_dependabot and should_install_automerge:
-        logging.error(
+        logger.error(
             "ERROR: You must install dependabot if you want to install the automerge workflow."  # noqa: B950, E501
         )
         sys.exit(1)
     elif not should_install_gh_actions and should_install_automerge:
-        logging.error(
+        logger.error(
             "ERROR: You must install Github Actions if you want to install the Dependabot automerge workflow."  # noqa: B950, E501
         )
         sys.exit(1)

--- a/{{cookiecutter.package_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.package_name}}/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
     hooks:
       - id: mypy
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.1
+    rev: v0.11.7
     hooks:
     - id: ruff
       args: ['--config', 'pyproject.toml']

--- a/{{cookiecutter.package_name}}/pyproject.toml
+++ b/{{cookiecutter.package_name}}/pyproject.toml
@@ -33,7 +33,7 @@ dev = [
     "tox>={{ cookiecutter.tox_version }}",
     "hypothesis>=6.115.5,<7",
     "mutmut>=3.2.0,<4",
-    "ruff>=0.7.1,<0.8",
+    "ruff>=0.11.7,<0.16",
     "deptry>=0.20.0,<0.21",
 ]
 docs = [


### PR DESCRIPTION
## Summary

- Template `pyproject.toml` pinned `ruff>=0.7.1,<0.8`, producing generated projects locked to a ~year-old ruff. Bumped to `ruff>=0.11.7,<0.16` to match the root.
- Template `.pre-commit-config.yaml` ruff rev was `v0.7.1`, root was `v0.7.3`. Both bumped to `v0.11.7` so the pre-commit rev stays inside the pyproject pin range.

## Test plan

- [x] `uv run tox run -e py312` passes (157 tests)
- [ ] CI green on push

