### PR TITLE
fix(template): align docs.yml python-version with cookiecutter.python_version

### DIFF
--- a/{{cookiecutter.package_name}}/.github/workflows/docs.yml
+++ b/{{cookiecutter.package_name}}/.github/workflows/docs.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.11"
+          - "{{ cookiecutter.python_version }}"
         os: [ubuntu-latest]
         env:
           - TOXENV: "docs"


### PR DESCRIPTION
## Summary
- The docs workflow matrix in the template hardcoded `"3.11"` for `python-version` while `ci.yml` and `publish.yml` use `{{ cookiecutter.python_version }}`.
- Generated projects that select a different `python_version` would still build docs on 3.11.
- Aligns `{{cookiecutter.package_name}}/.github/workflows/docs.yml:23` with the rest of the workflow templates.

## Test plan
- [ ] `just tests` passes (existence-only assertion on `docs.yml` is unaffected; `python_version` parameterized tests render the docs job with the chosen version).
- [ ] Manual: bake the template with `python_version=3.13` and confirm `.github/workflows/docs.yml` shows `- "3.13"`.