### PR TITLE
fix(template): bump astral-sh/setup-uv from v6 to v7 in workflows

### DIFF
--- a/{{cookiecutter.package_name}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.package_name}}/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           python-version: {% raw %}${{ matrix.python-version }}{% endraw %}
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           version: {% raw %}${{ env.UV_VERSION }}{% endraw %}
           enable-cache: true
@@ -66,7 +66,7 @@ jobs:
         with:
           python-version: {% raw %}${{ matrix.python-version }}{% endraw %}
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           version: {% raw %}${{ env.UV_VERSION }}{% endraw %}
           enable-cache: true

--- a/{{cookiecutter.package_name}}/.github/workflows/docs.yml
+++ b/{{cookiecutter.package_name}}/.github/workflows/docs.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           python-version: {% raw %}${{ matrix.python-version }}{% endraw %}
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           version: {% raw %}${{ env.UV_VERSION }}{% endraw %}
           enable-cache: true

--- a/{{cookiecutter.package_name}}/.github/workflows/publish.yml
+++ b/{{cookiecutter.package_name}}/.github/workflows/publish.yml
@@ -42,7 +42,7 @@ jobs:
           python-version: {% raw %}${{ env.PYTHON_VERSION }}{% endraw %}
 
       - name: Install uv {% raw %}${{ env.UV_VERSION }}{% endraw %}
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           version: {% raw %}${{ env.UV_VERSION }}{% endraw %}
           enable-cache: true
@@ -85,7 +85,7 @@ jobs:
           path: dist/
 
       - name: Install uv {% raw %}${{ env.UV_VERSION }}{% endraw %}
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           version: {% raw %}${{ env.UV_VERSION }}{% endraw %}
           enable-cache: true
@@ -122,7 +122,7 @@ jobs:
           path: dist/
 
       - name: Install uv {% raw %}${{ env.UV_VERSION }}{% endraw %}
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           version: {% raw %}${{ env.UV_VERSION }}{% endraw %}
           enable-cache: true
@@ -159,7 +159,7 @@ jobs:
           path: dist/
 
       - name: Install uv {% raw %}${{ env.UV_VERSION }}{% endraw %}
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           version: {% raw %}${{ env.UV_VERSION }}{% endraw %}
           enable-cache: true


### PR DESCRIPTION
## Summary
- Bumps `astral-sh/setup-uv` from `@v6` to `@v7` across the template's three workflows (`ci.yml`, `docs.yml`, `publish.yml`), matching the root project's workflows.
- 7 occurrences updated total.

## Test plan
- [ ] `just tests` passes (no test asserts the action version, so this should be a no-op).
- [ ] Manual: bake the template and confirm `.github/workflows/{ci,docs,publish}.yml` reference `astral-sh/setup-uv@v7`.
