### PR TITLE
docs: document release flow

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -56,6 +56,9 @@ exclude-contributors:
   - dependabot[bot]
 
 autolabeler:
+  - label: "skip-changelog"
+    title:
+      - '/\[skip\]/'
   - label: "documentation"
     branch:
       - '/docs{0,1}\/.+/'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -56,9 +56,6 @@ exclude-contributors:
   - dependabot[bot]
 
 autolabeler:
-  - label: "skip-changelog"
-    title:
-      - '/\[skip\]/'
   - label: "documentation"
     branch:
       - '/docs{0,1}\/.+/'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ gh release create 2.0.0 --generate-notes
 
 ### Skipping a PR from release notes
 
-Add `[skip]` to the PR title. The drafter autolabeler tags the PR with `skip-changelog`, and `exclude-labels` keeps it out of the next release's changelog and version bump.
+Apply the `skip-changelog` label to the PR. `exclude-labels` in `.github/release-drafter.yml` keeps labelled PRs out of the next release's changelog and version bump.
 
 ## Important Considerations
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,32 @@ The project tests the cookiecutter template generation process:
 - `hooks/post_gen_project.py` - Post-generation script that conditionally removes files based on user selections
 - `hooks/pre_gen_project.py` - Pre-generation validation script
 
+## Releases
+
+Tags use plain SemVer with no `v` prefix (e.g. `2.0.0`). The `publish.yml` workflow fires on `release: published` and derives the wheel version from the tag via `dunamai from git --style semver`.
+
+### Drafter flow (default)
+
+`release-drafter` maintains a draft release on every push to `main`. Version bumps come from PR labels (configured in `.github/release-drafter.yml`):
+
+- `feature` → minor
+- `fix`, `refactor`, `build`, `documentation`, `dependencies`, `performance` → patch
+- `breaking` → currently minor (move it under `version-resolver.major` if you want true major automation)
+
+Open the draft on GitHub, confirm the tag, click **Publish**. That fires `publish.yml`.
+
+### Manual flow (forced major or off-cycle cuts)
+
+```sh
+git tag -a 2.0.0 -m "2.0.0"
+git push origin 2.0.0
+gh release create 2.0.0 --generate-notes
+```
+
+### Skipping a PR from release notes
+
+Add `[skip]` to the PR title. The drafter autolabeler tags the PR with `skip-changelog`, and `exclude-labels` keeps it out of the next release's changelog and version bump.
+
 ## Important Considerations
 
 When working with this codebase, be aware that changes may affect both:

--- a/README.md
+++ b/README.md
@@ -177,6 +177,28 @@ If you enable the PyPi workflow, versioning will happen via [`dunamai`](https://
 
 If instead, you prefer to version your package, please do it via ```uv version $(dunamai from any)``` as recommended in their [documentation](https://github.com/mtkennerly/dunamai#user-content-integration).
 
+### Publishing a Release
+
+Tags use plain SemVer with no `v` prefix (e.g. `2.0.0`). The `publish.yml` workflow fires on `release: published` and derives the wheel version from the tag via `dunamai from git --style semver`.
+
+Two paths:
+
+**Drafter (default).** [`release-drafter`](https://github.com/release-drafter/release-drafter) maintains a draft on every push to `main`. Version resolves from PR labels: `breaking` → major-ish bump (currently mapped to minor — adjust `version-resolver` if you want true major automation), `feature` → minor, `fix` / `refactor` / `build` / `documentation` / `dependencies` / `performance` → patch. Open the draft, confirm the tag, click **Publish**.
+
+**Manual (forced major or off-cycle cuts).**
+
+```sh
+git tag -a 2.0.0 -m "2.0.0"
+git push origin 2.0.0
+gh release create 2.0.0 --generate-notes
+```
+
+Publishing triggers `publish.yml` which builds the sdist/wheel and uploads them as a GitHub Actions artifact.
+
+#### Skipping a PR from release notes
+
+Add `[skip]` to the PR title. The drafter autolabeler tags it with `skip-changelog`, and `exclude-labels` in `.github/release-drafter.yml` keeps it out of the next release's changelog and version bump.
+
 ### Configuration Variables
 
 When you run cookiecutter, you'll be prompted for various configuration options. Here are the key variables:

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Publishing triggers `publish.yml` which builds the sdist/wheel and uploads them 
 
 #### Skipping a PR from release notes
 
-Add `[skip]` to the PR title. The drafter autolabeler tags it with `skip-changelog`, and `exclude-labels` in `.github/release-drafter.yml` keeps it out of the next release's changelog and version bump.
+Apply the `skip-changelog` label to the PR. `exclude-labels` in `.github/release-drafter.yml` keeps labelled PRs out of the next release's changelog and version bump.
 
 ### Configuration Variables
 


### PR DESCRIPTION
## Summary
- Document drafter + manual release paths in `README.md` and `CLAUDE.md`
- Note tags use plain SemVer (no `v` prefix) and that `publish.yml` fires on `release: published`
- Document the existing `skip-changelog` label as the way to exclude a PR from drafted release notes

## Test plan
- [ ] Apply `skip-changelog` to a throwaway PR, confirm drafter excludes it from the next draft
