### PR TITLE
feat(docs): version docs by release + rolling latest with switcher

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,8 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  release:
+    types: [ published ]
 
   # manual
   workflow_dispatch:
@@ -63,10 +65,91 @@ jobs:
         with:
           name: html_docs
           path: ./artifact
-      - name: Deploy to gh pages
-        if: ${{ github.event_name == 'push' && github.ref_name ==  github.event.repository.default_branch }}
-        uses: peaceiris/actions-gh-pages@v4
+
+  deploy:
+    needs: tox-docs
+    if: >-
+      ${{ (github.event_name == 'push' && github.ref_name == github.event.repository.default_branch)
+          || github.event_name == 'release'
+          || github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    concurrency:
+      group: docs-gh-pages
+      cancel-in-progress: false
+    steps:
+      - name: Determine destination directory
+        id: dest
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo "dir=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "dir=latest" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Checkout gh-pages
+        uses: actions/checkout@v6
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: .tox/docs_out/
-          destination_dir: ./latest
+          ref: gh-pages
+          path: gh-pages
+      - name: Download docs artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: html_docs
+          path: ./artifact
+      - name: Sync HTML into version directory
+        shell: bash
+        run: |
+          DEST="${{ steps.dest.outputs.dir }}"
+          rm -rf "gh-pages/${DEST}"
+          mkdir -p "gh-pages/${DEST}"
+          cp -a artifact/html_docs/. "gh-pages/${DEST}/"
+      - name: Regenerate versions.json
+        shell: bash
+        working-directory: gh-pages
+        run: |
+          touch .nojekyll
+          python3 - <<'PY'
+          import json, pathlib, re
+
+          root = pathlib.Path(".")
+          version_re = re.compile(r"^\d+\.\d+\.\d+([._-].+)?$")
+
+          entries = []
+          for child in sorted(root.iterdir()):
+              if not child.is_dir() or child.name.startswith("."):
+                  continue
+              name = child.name
+              if name == "latest" or version_re.match(name):
+                  entries.append(name)
+
+          def sort_key(name: str):
+              if name == "latest":
+                  return (0, ())
+              parts = re.split(r"[._-]", name)
+              nums = []
+              for part in parts:
+                  try:
+                      nums.append(int(part))
+                  except ValueError:
+                      nums.append(part)
+              return (1, tuple(-n if isinstance(n, int) else n for n in nums))
+
+          entries.sort(key=sort_key)
+          payload = [{"name": name, "url": f"/cookiecutter-py/{name}/"} for name in entries]
+          pathlib.Path("versions.json").write_text(json.dumps(payload, indent=2) + "\n")
+          PY
+      - name: Commit and push
+        shell: bash
+        working-directory: gh-pages
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No changes to publish."
+            exit 0
+          fi
+          git commit -m "deploy: ${{ steps.dest.outputs.dir }} from ${GITHUB_SHA}"
+          git push origin gh-pages

--- a/docs/_static/version-switcher.css
+++ b/docs/_static/version-switcher.css
@@ -1,0 +1,28 @@
+.sidebar-version-selector {
+  margin: 0.5rem 1rem 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: var(--font-size--small);
+}
+
+.sidebar-version-selector__label {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-foreground-muted);
+}
+
+.sidebar-version-selector__select {
+  width: 100%;
+  padding: 0.25rem 0.5rem;
+  background: var(--color-background-secondary);
+  color: var(--color-foreground-primary);
+  border: 1px solid var(--color-background-border);
+  border-radius: 0.25rem;
+  font: inherit;
+}
+
+.sidebar-version-selector__select:disabled {
+  opacity: 0.6;
+}

--- a/docs/_static/version-switcher.js
+++ b/docs/_static/version-switcher.js
@@ -1,0 +1,92 @@
+(function () {
+  "use strict";
+
+  function detectCurrentVersion() {
+    const segments = window.location.pathname.split("/").filter(Boolean);
+    // GH pages serves at /<repo>/<version>/...
+    // index 0 is the repo name, index 1 is the version slug.
+    if (segments.length >= 2) {
+      return segments[1];
+    }
+    return "";
+  }
+
+  function buildVersionsUrl() {
+    const segments = window.location.pathname.split("/").filter(Boolean);
+    if (segments.length === 0) {
+      return "/versions.json";
+    }
+    return "/" + segments[0] + "/versions.json";
+  }
+
+  function navigateTo(slug) {
+    const segments = window.location.pathname.split("/").filter(Boolean);
+    if (segments.length < 1) {
+      window.location.pathname = "/" + slug + "/";
+      return;
+    }
+    const tail = segments.slice(2).join("/");
+    const suffix = tail ? "/" + tail : "/";
+    window.location.pathname = "/" + segments[0] + "/" + slug + suffix;
+  }
+
+  function populate(select, entries, current) {
+    select.innerHTML = "";
+    let matched = false;
+    entries.forEach(function (entry) {
+      const option = document.createElement("option");
+      option.value = entry.name;
+      option.textContent = entry.name;
+      if (entry.name === current) {
+        option.selected = true;
+        matched = true;
+      }
+      select.appendChild(option);
+    });
+    if (!matched && current) {
+      const option = document.createElement("option");
+      option.value = current;
+      option.textContent = current + " (current)";
+      option.selected = true;
+      select.insertBefore(option, select.firstChild);
+    }
+  }
+
+  function init() {
+    const select = document.getElementById("cc-version-select");
+    if (!select) {
+      return;
+    }
+    const current = detectCurrentVersion();
+    fetch(buildVersionsUrl(), { cache: "no-store" })
+      .then(function (response) {
+        if (!response.ok) {
+          throw new Error("versions.json HTTP " + response.status);
+        }
+        return response.json();
+      })
+      .then(function (entries) {
+        populate(select, entries, current);
+        select.addEventListener("change", function () {
+          if (select.value) {
+            navigateTo(select.value);
+          }
+        });
+      })
+      .catch(function (err) {
+        console.warn("version-switcher: failed to load versions.json", err);
+        select.innerHTML = "";
+        const option = document.createElement("option");
+        option.textContent = current || "current";
+        option.selected = true;
+        select.appendChild(option);
+        select.disabled = true;
+      });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/docs/_templates/sidebar/version-selector.html
+++ b/docs/_templates/sidebar/version-selector.html
@@ -1,0 +1,6 @@
+<div class="sidebar-version-selector">
+  <label for="cc-version-select" class="sidebar-version-selector__label">Version</label>
+  <select id="cc-version-select" class="sidebar-version-selector__select" aria-label="Select documentation version">
+    <option value="">loading…</option>
+  </select>
+</div>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,3 +56,18 @@ myst_enable_extensions = [
 
 html_theme = 'furo'
 html_static_path = ['_static']
+html_css_files = ['version-switcher.css']
+html_js_files = ['version-switcher.js']
+
+html_sidebars = {
+    '**': [
+        'sidebar/brand.html',
+        'sidebar/search.html',
+        'sidebar/scroll-start.html',
+        'sidebar/navigation.html',
+        'sidebar/ethical-ads.html',
+        'sidebar/scroll-end.html',
+        'sidebar/version-selector.html',
+        'sidebar/variant-selector.html',
+    ],
+}


### PR DESCRIPTION
## Summary
- Versioned docs publishing for the root repo: `latest/` on push to `main`, `<tag>/` on `release: published`
- New `deploy` job replaces `peaceiris/actions-gh-pages` with a direct gh-pages checkout/commit so the HTML drop and `versions.json` regeneration land in a single commit
- `versions.json` is regenerated at the gh-pages root after every deploy; tags sorted descending, `latest` first
- Furo sidebar gets a `version-selector.html` entry; `_static/version-switcher.{js,css}` fetches `versions.json` at runtime and rewrites the URL while keeping the current page path

## Layout
```
gh-pages/
  latest/        # overwritten on every merge to main
  2.0.0/         # pinned, immutable
  1.0.0/
  versions.json
  .nojekyll
```

URLs:
- https://ryankanno.github.io/cookiecutter-py/latest/
- https://ryankanno.github.io/cookiecutter-py/2.0.0/

## Notes
- Concurrency lock (`docs-gh-pages`) prevents simultaneous release + main-push deploys from racing.
- Existing `1.0.0/` and `2.0.0/` directories on gh-pages will not appear in the dropdown until a deploy regenerates `versions.json`. The next merge to main, or a manual `workflow_dispatch`, will seed it.
- Local Sphinx builds (file://) cannot fetch `versions.json`; the dropdown gracefully degrades to showing the current version only.
- Template (`{{cookiecutter.package_name}}/.github/workflows/docs.yml`) intentionally unchanged in this PR. Will follow up once this is validated in production.

## Test plan
- [x] `uv run --group docs sphinx-build -E -b html docs /tmp/out` builds clean and embeds `version-switcher.{js,css}` + `#cc-version-select`
- [ ] Merge → confirm `deploy` job creates `latest/` plus `versions.json`
- [ ] Tag a no-op release → confirm `<tag>/` directory appears and dropdown lists it
- [ ] Open `https://ryankanno.github.io/cookiecutter-py/latest/`, verify dropdown populates and navigation works
