### PR TITLE
feat(docs): workflow_dispatch ref/version inputs for backfill

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,8 +8,17 @@ on:
   release:
     types: [ published ]
 
-  # manual
+  # manual; optionally backfill a specific tag's docs to a named version dir
   workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref to build docs from (branch, tag, or SHA). Defaults to the branch the workflow is dispatched from.'
+        required: false
+        default: ''
+      version:
+        description: 'Destination directory under gh-pages (e.g. 2.0.0, latest). Defaults to latest.'
+        required: false
+        default: ''
 
 env:
   UV_VERSION: 0.7.3
@@ -31,6 +40,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
       - name: Configure Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
         with:
@@ -85,6 +96,8 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "release" ]; then
             echo "dir=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.version }}" ]; then
+            echo "dir=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
           else
             echo "dir=latest" >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
## Summary
Adds two `workflow_dispatch` inputs to `docs.yml` so we can backfill historical tag docs:

- `ref` — git ref (branch / tag / SHA) to build docs from. Wired into the `actions/checkout` for the build job.
- `version` — destination directory under gh-pages. Honored in the deploy job's destination-resolution step.

## Why
PR #597 added per-release docs, but the `release: published` trigger reads `docs.yml` from the **tag's commit**. Existing tags `1.0.0` and `2.0.0` predate that trigger, so re-publishing those releases wouldn't deploy anything.

`workflow_dispatch` runs the workflow file from the branch it's dispatched from (main, post-merge), and our `ref` input controls only the source checkout. That lets us build historical tags using the *current* deploy plumbing without rewriting any tags.

## How to backfill after merge

```sh
gh workflow run docs.yml -f ref=1.0.0 -f version=1.0.0
gh workflow run docs.yml -f ref=2.0.0 -f version=2.0.0
```

Each run:
1. Checks out the tag's source (`1.0.0` → `26ffe28`, `2.0.0` → `f7101a6`)
2. Builds docs from that tree
3. Deploys to `gh-pages/<version>/`
4. Regenerates `versions.json` at the gh-pages root

## Defaults
With no inputs, behavior is unchanged: workflow_dispatch deploys main's docs to `/latest/`.

## Test plan
- [x] YAML parses (pushed to GitHub successfully)
- [ ] After merge: `gh workflow run docs.yml -f ref=2.0.0 -f version=2.0.0`, confirm `gh-pages/2.0.0/` appears and dropdown lists it
- [ ] Repeat for `1.0.0`
- [ ] Sanity check: trigger a release on a throwaway tag, confirm normal release path still works
