### PR TITLE
fix(docs): publish gh-pages tree via actions/deploy-pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -86,9 +86,14 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pages: write
+      id-token: write
     concurrency:
-      group: docs-gh-pages
+      group: pages
       cancel-in-progress: false
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Determine destination directory
         id: dest
@@ -153,7 +158,7 @@ jobs:
           payload = [{"name": name, "url": f"/cookiecutter-py/{name}/"} for name in entries]
           pathlib.Path("versions.json").write_text(json.dumps(payload, indent=2) + "\n")
           PY
-      - name: Commit and push
+      - name: Commit and push gh-pages branch
         shell: bash
         working-directory: gh-pages
         run: |
@@ -161,8 +166,23 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -A
           if git diff --cached --quiet; then
-            echo "No changes to publish."
-            exit 0
+            echo "No gh-pages changes to publish."
+          else
+            git commit -m "deploy: ${{ steps.dest.outputs.dir }} from ${GITHUB_SHA}"
+            git push origin gh-pages
           fi
-          git commit -m "deploy: ${{ steps.dest.outputs.dir }} from ${GITHUB_SHA}"
-          git push origin gh-pages
+      - name: Stage Pages payload
+        shell: bash
+        run: |
+          mkdir -p _pages_payload
+          cp -a gh-pages/. _pages_payload/
+          rm -rf _pages_payload/.git
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _pages_payload
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
Live Pages site has been frozen at the 2025-09-20 snapshot. Root cause: GitHub Pages config flipped to `build_type: workflow`, which disabled the legacy auto-build-on-push-to-gh-pages path. Every deploy since (including `latest/`, `1.0.0/`, `2.0.0/`) updated the gh-pages branch but did not publish.

This PR migrates the deploy job to the modern `actions/deploy-pages` pattern while keeping gh-pages as the per-version storage backend, so all existing tooling (workflow_dispatch backfill, versions.json regeneration, release-triggered tag deploys) continues to work unchanged.

## What changed in `docs.yml`
- `deploy` job gains `pages: write` + `id-token: write` permissions and the `github-pages` environment.
- Concurrency group renamed `docs-gh-pages` → `pages` to align with GitHub's documented pattern for Pages deployments.
- After committing to the gh-pages branch, the workflow now:
  1. Stages a copy of the gh-pages tree minus `.git` into `_pages_payload/`.
  2. Calls `actions/configure-pages@v5`.
  3. Uploads `_pages_payload` via `actions/upload-pages-artifact@v3`.
  4. Publishes via `actions/deploy-pages@v4`.

## Why keep gh-pages branch
- Incremental per-version updates: each deploy only touches one directory.
- Backfill via `workflow_dispatch` keeps writing to the same store.
- History is preserved for free.
- The Pages artifact is reconstructed from the branch on every deploy, so the branch is the source of truth and the artifact is just the publishing transport.

## After merge
The merge commit triggers the workflow. It will:
- Rebuild `latest/` from main HEAD (post-merge tree).
- Push gh-pages with new `latest/` content.
- Publish the full gh-pages tree (`latest`, `1.0.0`, `2.0.0`, `versions.json`, `.nojekyll`) to Pages.

Expected URLs to come live within ~1 min of the deploy job finishing:
- https://ryankanno.github.io/cookiecutter-py/latest/ (with version selector)
- https://ryankanno.github.io/cookiecutter-py/2.0.0/
- https://ryankanno.github.io/cookiecutter-py/1.0.0/

## Test plan
- [x] YAML syntax valid (pushed to remote)
- [ ] Merge → confirm `deploy` job's `Deploy to GitHub Pages` step succeeds and reports a `page_url`
- [ ] `curl -s https://ryankanno.github.io/cookiecutter-py/latest/ | grep -o cc-version-select` returns a match
- [ ] `/1.0.0/` and `/2.0.0/` resolve (200) and dropdown lists all three
