### PR TITLE
feat(docs): surface current version next to brand text

### DIFF
--- a/docs/_static/version-switcher.css
+++ b/docs/_static/version-switcher.css
@@ -26,3 +26,28 @@
 .sidebar-version-selector__select:disabled {
   opacity: 0.6;
 }
+
+.cc-version-badge {
+  display: inline-block;
+  margin-left: 0.5rem;
+  padding: 0.05rem 0.4rem;
+  border-radius: 0.6rem;
+  background: var(--color-brand-primary, var(--color-background-secondary));
+  color: var(--color-background-primary, #fff);
+  font-size: 0.75em;
+  font-weight: 600;
+  line-height: 1.4;
+  letter-spacing: 0.02em;
+  vertical-align: middle;
+}
+
+.sidebar-brand-text .cc-version-badge {
+  background: var(--color-foreground-primary);
+  color: var(--color-background-primary);
+  opacity: 0.85;
+}
+
+.mobile-header .header-center .brand .cc-version-badge {
+  font-size: 0.7em;
+  padding: 0.02rem 0.35rem;
+}

--- a/docs/_static/version-switcher.js
+++ b/docs/_static/version-switcher.js
@@ -52,12 +52,33 @@
     }
   }
 
+  function injectBrandBadge(current) {
+    if (!current) {
+      return;
+    }
+    const targets = [
+      document.querySelector(".sidebar-brand-text"),
+      document.querySelector(".mobile-header .header-center .brand"),
+    ];
+    targets.forEach(function (target) {
+      if (!target || target.querySelector(".cc-version-badge")) {
+        return;
+      }
+      const badge = document.createElement("span");
+      badge.className = "cc-version-badge";
+      badge.textContent = current;
+      badge.setAttribute("title", "Documentation version " + current);
+      target.appendChild(badge);
+    });
+  }
+
   function init() {
     const select = document.getElementById("cc-version-select");
+    const current = detectCurrentVersion();
+    injectBrandBadge(current);
     if (!select) {
       return;
     }
-    const current = detectCurrentVersion();
     fetch(buildVersionsUrl(), { cache: "no-store" })
       .then(function (response) {
         if (!response.ok) {


### PR DESCRIPTION
## Summary
Surfaces the active doc version next to the brand text so it's always visible without scrolling the sidebar to find the dropdown.

`version-switcher.js` now injects a `.cc-version-badge` chip into:
- `.sidebar-brand-text` (top of the sidebar drawer — desktop and mobile hamburger view)
- `.mobile-header .header-center .brand` (the mobile top bar)

The badge is a read-only label reflecting `detectCurrentVersion()`. The existing dropdown stays in the sidebar for switching versions.

## Rendering
- Sidebar brand: `cookiecutter-py documentation [2.0.0]`
- Mobile header: `cookiecutter-py documentation [2.0.0]`

Badge styled per location via `_static/version-switcher.css` (slightly smaller in the mobile header to fit the compact layout).

## Test plan
- [x] Local Sphinx build embeds the new JS + CSS (`grep cc-version-badge` matches in `_static`)
- [x] `node --check` on the built JS passes
- [ ] After merge: badge appears next to "cookiecutter-py documentation" in both desktop sidebar header and mobile top bar
- [ ] Navigating to `/2.0.0/` shows `2.0.0` badge; `/1.0.0/` shows `1.0.0`; `/latest/` shows `latest`
