### PR TITLE
feat(docs): overlay current theme assets when rebuilding old tags

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,6 +42,63 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref || github.ref }}
+          fetch-depth: 0
+      - name: Overlay docs theme assets from default branch
+        if: github.event_name == 'workflow_dispatch' && inputs.ref != ''
+        shell: bash
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          git fetch origin "${DEFAULT_BRANCH}"
+          REF="origin/${DEFAULT_BRANCH}"
+          mkdir -p docs/_static docs/_templates/sidebar
+          git show "${REF}:docs/_static/version-switcher.js"  > docs/_static/version-switcher.js
+          git show "${REF}:docs/_static/version-switcher.css" > docs/_static/version-switcher.css
+          git show "${REF}:docs/_templates/sidebar/version-selector.html" \
+            > docs/_templates/sidebar/version-selector.html
+          if [ -s docs/conf.py ] && [ "$(tail -c 1 docs/conf.py | wc -c)" -ne 0 ]; then
+            printf '\n' >> docs/conf.py
+          fi
+          cat >> docs/conf.py <<'PYCONF'
+
+          # --- docs theme overlay (injected during backfill builds) ---
+          _overlay_templates = list(globals().get("templates_path", []) or [])
+          if "_templates" not in _overlay_templates:
+              _overlay_templates.append("_templates")
+          templates_path = _overlay_templates
+
+          _overlay_static = list(globals().get("html_static_path", []) or [])
+          if "_static" not in _overlay_static:
+              _overlay_static.append("_static")
+          html_static_path = _overlay_static
+
+          html_css_files = list(globals().get("html_css_files", []) or []) + [
+              "version-switcher.css",
+          ]
+          html_js_files = list(globals().get("html_js_files", []) or []) + [
+              "version-switcher.js",
+          ]
+
+          _overlay_sidebars = dict(globals().get("html_sidebars", {}) or {})
+          _overlay_default = [
+              "sidebar/brand.html",
+              "sidebar/search.html",
+              "sidebar/scroll-start.html",
+              "sidebar/navigation.html",
+              "sidebar/ethical-ads.html",
+              "sidebar/scroll-end.html",
+              "sidebar/version-selector.html",
+              "sidebar/variant-selector.html",
+          ]
+          if "**" in _overlay_sidebars:
+              if "sidebar/version-selector.html" not in _overlay_sidebars["**"]:
+                  _overlay_sidebars["**"].insert(-1, "sidebar/version-selector.html")
+          else:
+              _overlay_sidebars["**"] = _overlay_default
+          html_sidebars = _overlay_sidebars
+          # --- end docs theme overlay ---
+          PYCONF
       - name: Configure Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
## Summary
Lets `workflow_dispatch` backfill rebuilds of old tags (1.0.0, 2.0.0, etc.) ship with the current doc theme chrome — version selector dropdown + version badge — even though those tags' source trees predate the theme assets.

## What changed
A new `Overlay docs theme assets from default branch` step in the `tox-docs` job. It only runs on `workflow_dispatch` with a non-empty `ref` input. The step:

1. Fetches the default branch (full history, `fetch-depth: 0` on checkout).
2. `git show`s these files from `origin/<default-branch>` and writes them into the checked-out tag's tree:
   - `docs/_static/version-switcher.js`
   - `docs/_static/version-switcher.css`
   - `docs/_templates/sidebar/version-selector.html`
3. Appends a self-composing snippet to `docs/conf.py` that extends (rather than replaces) `templates_path`, `html_static_path`, `html_css_files`, `html_js_files`, and `html_sidebars`.

The snippet uses `globals().get(...)` and idempotent inserts, so it's safe if the tag's `conf.py` already defines any of these. The `sidebar/version-selector.html` entry is positioned just before `variant-selector.html` to match the current main build.

## Why
Without this overlay, `gh workflow run docs.yml -f ref=1.0.0 -f version=1.0.0` rebuilds from `26ffe28` (tag 1.0.0's commit), which has no `version-switcher.{js,css}` and no sidebar entry. The rebuilt 1.0.0 docs would render in the pre-versioning chrome — no badge, no dropdown.

## Verified locally
- `python3 -c "import ast; ast.parse(open('conf.py').read())"` passes against an overlay applied to tag 1.0.0's conf.py
- Executing the post-overlay conf.py as a Python module runs to completion without errors
- The YAML extracts cleanly to a properly-indented Python heredoc (verified via `yaml.safe_load` + visual inspection of stripped indentation)

## Usage after merge
```sh
gh workflow run docs.yml -f ref=2.0.0 -f version=2.0.0
gh workflow run docs.yml -f ref=1.0.0 -f version=1.0.0
```

Each run builds the tag's content with the current chrome and deploys to `gh-pages/<version>/`, then `versions.json` regenerates and Pages re-publishes.

## Test plan
- [x] Local AST parse of overlaid conf.py
- [x] YAML extraction confirms script lines land at column 0
- [ ] After merge: dispatch with `ref=2.0.0 version=2.0.0`, confirm `/2.0.0/` renders the version badge + dropdown
- [ ] Repeat for `1.0.0`
- [ ] Regular `push` to main still deploys `/latest/` without running the overlay step (`if:` guard on event_name + non-empty ref)
