### PR TITLE
feat(docs): show source commit hash in footer

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -97,6 +97,27 @@ jobs:
           else:
               _overlay_sidebars["**"] = _overlay_default
           html_sidebars = _overlay_sidebars
+
+          import os as _overlay_os
+          import subprocess as _overlay_subprocess
+
+          def _overlay_commit_short():
+              sha = _overlay_os.environ.get("GITHUB_SHA", "")
+              try:
+                  result = _overlay_subprocess.run(
+                      ["git", "rev-parse", "--short", "HEAD"],
+                      cwd=_overlay_os.path.dirname(_overlay_os.path.abspath(__file__)),
+                      capture_output=True,
+                      text=True,
+                      check=True,
+                  )
+                  return result.stdout.strip()
+              except (_overlay_subprocess.CalledProcessError, FileNotFoundError):
+                  return sha[:7] if sha else ""
+
+          _overlay_sha = _overlay_commit_short()
+          if _overlay_sha and "build " not in str(globals().get("copyright", "")):
+              copyright = f'{globals().get("copyright", "")} · build {_overlay_sha}'
           # --- end docs theme overlay ---
           PYCONF
       - name: Configure Python ${{ matrix.python-version }}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,10 +4,27 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
 import os
+import subprocess
 import sys
 
 
 sys.path.insert(0, os.path.abspath('../cookiecutter_py/'))
+
+
+def _detect_commit_short() -> str:
+    sha = os.environ.get('GITHUB_SHA', '')
+    try:
+        result = subprocess.run(
+            ['git', 'rev-parse', '--short', 'HEAD'],
+            cwd=os.path.dirname(os.path.abspath(__file__)),
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return sha[:7] if sha else ''
+
 
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
@@ -15,6 +32,10 @@ sys.path.insert(0, os.path.abspath('../cookiecutter_py/'))
 project = 'cookiecutter-py'
 copyright = '2024, Ryan Kanno'
 author = 'Ryan Kanno'
+
+_commit_short = _detect_commit_short()
+if _commit_short:
+    copyright = f'{copyright} · build {_commit_short}'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration


### PR DESCRIPTION
## Summary
Stamps each built page with its source commit so deployed docs are self-identifying:

```
Copyright © 2024, Ryan Kanno · build 75a8f20
```

Sits in the existing furo `<div class="copyright">` block at page bottom. Discreet, no extra UI.

## Implementation
- `docs/conf.py` detects the short SHA via `git rev-parse --short HEAD`, falling back to `$GITHUB_SHA[:7]` when git is unavailable (e.g., source archives).
- The workflow's `Overlay docs theme assets` step appends the same detection to backfilled tags' `conf.py` so historical tag rebuilds also stamp correctly. Idempotent: skips if `copyright` already contains `build ` so re-runs don't double up.

## What each build shows
- `latest/` → commit on `main` at the time of the deploy
- `2.0.0/` rebuilt via `gh workflow run docs.yml -f ref=2.0.0 -f version=2.0.0` → `f7101a6` (tag 2.0.0's commit)
- `1.0.0/` same path → `26ffe28`
- Local `sphinx-build` → working-tree HEAD

## Verified locally
- `sphinx-build` against current `main` renders `· build 75a8f20` in the copyright footer (matches `git rev-parse --short HEAD`)
- The workflow's heredoc-embedded Python snippet parses (`yaml.safe_load` + `ast.parse`)

## Test plan
- [x] Local build shows the build stamp
- [x] YAML/Python validity
- [ ] After merge: `/latest/` footer shows the merge commit
- [ ] Re-dispatch backfills (`ref=2.0.0 version=2.0.0`, `ref=1.0.0 version=1.0.0`) and confirm each version's footer shows the tag's commit
