### PR TITLE
feat(docs): link build hash + add repo links

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -118,6 +118,33 @@ jobs:
           _overlay_sha = _overlay_commit_short()
           if _overlay_sha and "build " not in str(globals().get("copyright", "")):
               copyright = f'{globals().get("copyright", "")} · build {_overlay_sha}'
+
+          _overlay_repo_url = "https://github.com/${{ github.repository }}"
+          _overlay_github_mark_svg = (
+              '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" '
+              'width="1em" height="1em" fill="currentColor" aria-hidden="true">'
+              '<path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 '
+              '5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49'
+              '-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 '
+              '1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78'
+              '-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 '
+              '0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53'
+              '-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 '
+              '3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 '
+              '0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"></path>'
+              '</svg>'
+          )
+          _overlay_theme_opts = dict(globals().get("html_theme_options", {}) or {})
+          _overlay_footer_icons = list(_overlay_theme_opts.get("footer_icons", []) or [])
+          if not any(i.get("name") == "GitHub" for i in _overlay_footer_icons):
+              _overlay_footer_icons.append({
+                  "name": "GitHub",
+                  "url": _overlay_repo_url,
+                  "html": _overlay_github_mark_svg,
+                  "class": "",
+              })
+          _overlay_theme_opts["footer_icons"] = _overlay_footer_icons
+          html_theme_options = _overlay_theme_opts
           # --- end docs theme overlay ---
           PYCONF
       - name: Configure Python ${{ matrix.python-version }}

--- a/docs/_static/version-switcher.js
+++ b/docs/_static/version-switcher.js
@@ -52,6 +52,46 @@
     }
   }
 
+  function deriveRepoUrl() {
+    const host = window.location.hostname || "";
+    const ghIoMatch = host.match(/^([^.]+)\.github\.io$/);
+    const segments = window.location.pathname.split("/").filter(Boolean);
+    if (!ghIoMatch || segments.length === 0) {
+      return null;
+    }
+    return "https://github.com/" + ghIoMatch[1] + "/" + segments[0];
+  }
+
+  function linkifyBuildHash() {
+    const copyright = document.querySelector(".copyright");
+    if (!copyright) {
+      return;
+    }
+    const repoUrl = deriveRepoUrl();
+    if (!repoUrl) {
+      return;
+    }
+    const text = copyright.textContent;
+    const match = text.match(/build ([a-f0-9]{7,40})/);
+    if (!match) {
+      return;
+    }
+    const sha = match[1];
+    const link = document.createElement("a");
+    link.href = repoUrl + "/commit/" + sha;
+    link.textContent = sha;
+    link.rel = "noopener";
+    link.target = "_blank";
+    link.className = "cc-build-commit";
+    copyright.innerHTML = "";
+    copyright.append(
+      document.createTextNode(text.slice(0, match.index)),
+      document.createTextNode("build "),
+      link,
+      document.createTextNode(text.slice(match.index + match[0].length))
+    );
+  }
+
   function injectBrandBadge(current) {
     if (!current) {
       return;
@@ -76,6 +116,7 @@
     const select = document.getElementById("cc-version-select");
     const current = detectCurrentVersion();
     injectBrandBadge(current);
+    linkifyBuildHash();
     if (!select) {
       return;
     }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -80,6 +80,36 @@ html_static_path = ['_static']
 html_css_files = ['version-switcher.css']
 html_js_files = ['version-switcher.js']
 
+_repo_url = 'https://github.com/ryankanno/cookiecutter-py'
+_github_mark_svg = (
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" '
+    'width="1em" height="1em" fill="currentColor" aria-hidden="true">'
+    '<path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 '
+    '5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49'
+    '-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 '
+    '1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78'
+    '-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 '
+    '0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53'
+    '-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 '
+    '3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 '
+    '0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"></path>'
+    '</svg>'
+)
+
+html_theme_options = {
+    'source_repository': _repo_url,
+    'source_branch': 'main',
+    'source_directory': 'docs/',
+    'footer_icons': [
+        {
+            'name': 'GitHub',
+            'url': _repo_url,
+            'html': _github_mark_svg,
+            'class': '',
+        },
+    ],
+}
+
 html_sidebars = {
     '**': [
         'sidebar/brand.html',


### PR DESCRIPTION
## Summary
Three touch points to make the repo discoverable from any built page:

1. **Footer build hash → GitHub commit link.** `version-switcher.js` rewrites the plain `build <sha>` in `.copyright` to an anchor pointing at the GitHub commit. Repo URL derived from `<owner>.github.io` + `/<repo>/` path segment, so it works whether the page is at `/latest/`, `/2.0.0/`, or `/1.0.0/`.
2. **"Edit this page" per page.** `conf.py` sets furo's `source_repository` / `source_branch` / `source_directory`, so every page gets the top-right edit + view-source link.
3. **GitHub icon in footer.** `conf.py` registers a `footer_icons` entry with an inline SVG mark, rendering a muted-link icon next to "Made with Sphinx".

## Backfill builds
The workflow's overlay step adds the `footer_icons` GitHub entry to the tag's `conf.py` (merged into any existing `html_theme_options`). The `source_edit_link` family is **intentionally not** added for backfills — tagged source is historical, so a live "Edit this page" pointing at a frozen tree would be misleading.

The commit-anchor JS works on backfills automatically because `version-switcher.js` is already overlaid from main.

## Verified locally
```
Copyright © 2024, Ryan Kanno · build 1f52df9
```
becomes the GitHub commit link at runtime (anchor injected by JS).

Per-page edit link visible at top of every page:
- `Edit this page` → `github.com/.../edit/main/docs/index.rst`
- `View this page` → `github.com/.../blob/main/docs/index.rst?plain=true`

Footer icon present in `.right-details .icons` with `aria-label="GitHub"`.

YAML/Python validity:
- `sphinx-build` produces a clean build with all three integrations rendering
- `node --check` on the built JS passes
- `yaml.safe_load` + `ast.parse` on the overlay's heredoc body parses

## Test plan
- [x] Local Sphinx build renders edit link, footer icon, build-hash text
- [x] JS syntax check
- [ ] After merge: confirm `/latest/` shows linked build hash, edit link, footer icon
- [ ] Re-dispatch backfills, confirm `/2.0.0/` and `/1.0.0/` get linked hash + footer icon (no edit link)
