### PR TITLE
feat(template): extend versioned docs to sphinx-rtd-theme + pydata-sphinx-theme

### DIFF
--- a/{{cookiecutter.package_name}}/.github/workflows/docs.yml
+++ b/{{cookiecutter.package_name}}/.github/workflows/docs.yml
@@ -24,6 +24,7 @@ env:
   UV_VERSION: {{ cookiecutter.uv_version }}
   TOX_VERSION: {{ cookiecutter.tox_version }}
   PRE_COMMIT_CACHE: ~/.cache/pre-commit
+  DOCS_VERSION_MATCH: {% raw %}${{ github.event_name == 'release' && github.event.release.tag_name || (github.event_name == 'workflow_dispatch' && inputs.version || 'latest') }}{% endraw %}
 
 jobs:
   tox-docs:
@@ -148,6 +149,67 @@ jobs:
           html_theme_options = _overlay_theme_opts
           # --- end docs theme overlay ---
           PYCONF
+{%- elif cookiecutter.sphinx_theme == 'sphinx-rtd-theme' %}
+      - name: Overlay docs theme assets from default branch
+        if: {% raw %}github.event_name == 'workflow_dispatch' && inputs.ref != ''{% endraw %}
+        shell: bash
+        env:
+          DEFAULT_BRANCH: {% raw %}${{ github.event.repository.default_branch }}{% endraw %}
+        run: |
+          set -euo pipefail
+          git fetch origin "${DEFAULT_BRANCH}"
+          REF="origin/${DEFAULT_BRANCH}"
+          mkdir -p docs/_static
+          git show "${REF}:docs/_static/version-switcher.js"  > docs/_static/version-switcher.js
+          git show "${REF}:docs/_static/version-switcher.css" > docs/_static/version-switcher.css
+          if [ -s docs/conf.py ] && [ "$(tail -c 1 docs/conf.py | wc -c)" -ne 0 ]; then
+            printf '\n' >> docs/conf.py
+          fi
+          cat >> docs/conf.py <<'PYCONF'
+
+          # --- docs theme overlay (injected during backfill builds) ---
+          _overlay_static = list(globals().get("html_static_path", []) or [])
+          if "_static" not in _overlay_static:
+              _overlay_static.append("_static")
+          html_static_path = _overlay_static
+
+          html_css_files = list(globals().get("html_css_files", []) or []) + [
+              "version-switcher.css",
+          ]
+          html_js_files = list(globals().get("html_js_files", []) or []) + [
+              "version-switcher.js",
+          ]
+
+          _overlay_ctx = dict(globals().get("html_context", {}) or {})
+          _overlay_ctx.setdefault("display_github", True)
+          _overlay_ctx.setdefault("github_version", "main")
+          _overlay_ctx.setdefault("conf_py_path", "/docs/")
+          html_context = _overlay_ctx
+
+          import os as _overlay_os
+          import subprocess as _overlay_subprocess
+
+          def _overlay_commit_short():
+              sha = _overlay_os.environ.get("GITHUB_SHA", "")
+              try:
+                  result = _overlay_subprocess.run(
+                      ["git", "rev-parse", "--short", "HEAD"],
+                      cwd=_overlay_os.path.dirname(_overlay_os.path.abspath(__file__)),
+                      capture_output=True,
+                      text=True,
+                      check=True,
+                  )
+                  return result.stdout.strip()
+              except (_overlay_subprocess.CalledProcessError, FileNotFoundError):
+                  return sha[:7] if sha else ""
+
+          _overlay_sha = _overlay_commit_short()
+          if _overlay_sha and "build " not in str(globals().get("project_copyright", globals().get("copyright", ""))):
+              _existing_copyright = globals().get("project_copyright", globals().get("copyright", ""))
+              project_copyright = f'{_existing_copyright} · build {_overlay_sha}'
+              copyright = project_copyright
+          # --- end docs theme overlay ---
+          PYCONF
 {%- endif %}
       - name: Configure Python {% raw %}${{ matrix.python-version }}{% endraw %}
         uses: actions/setup-python@v6
@@ -234,6 +296,7 @@ jobs:
         shell: bash
         working-directory: gh-pages
         env:
+          REPO_OWNER: {% raw %}${{ github.repository_owner }}{% endraw %}
           REPO_NAME: {% raw %}${{ github.event.repository.name }}{% endraw %}
         run: |
           touch .nojekyll
@@ -242,7 +305,9 @@ jobs:
 
           root = pathlib.Path(".")
           version_re = re.compile(r"^\d+\.\d+\.\d+([._-].+)?$")
+          owner = os.environ["REPO_OWNER"]
           repo = os.environ["REPO_NAME"]
+          base = f"https://{owner}.github.io/{repo}"
 
           entries = []
           for child in sorted(root.iterdir()):
@@ -265,7 +330,10 @@ jobs:
               return (1, tuple(-n if isinstance(n, int) else n for n in nums))
 
           entries.sort(key=sort_key)
-          payload = [{"name": name, "url": f"/{repo}/{name}/"} for name in entries]
+          payload = [
+              {"name": name, "version": name, "url": f"{base}/{name}/"}
+              for name in entries
+          ]
           pathlib.Path("versions.json").write_text(json.dumps(payload, indent=2) + "\n")
           PY
       - name: Commit and push gh-pages branch

--- a/{{cookiecutter.package_name}}/docs/_static/version-switcher.css
+++ b/{{cookiecutter.package_name}}/docs/_static/version-switcher.css
@@ -51,3 +51,26 @@
   font-size: 0.7em;
   padding: 0.02rem 0.35rem;
 }
+
+/* sphinx-rtd-theme variant */
+.sidebar-version-selector--rtd {
+  padding: 0 1rem 0.75rem;
+  font-size: 0.85em;
+  color: #d9d9d9;
+}
+
+.sidebar-version-selector--rtd .sidebar-version-selector__label {
+  color: #b3b3b3;
+}
+
+.sidebar-version-selector--rtd .sidebar-version-selector__select {
+  background: #343131;
+  color: #d9d9d9;
+  border-color: #4e4a4a;
+}
+
+.wy-side-nav-search .cc-version-badge,
+.wy-nav-top .cc-version-badge {
+  background: rgba(255, 255, 255, 0.16);
+  color: #fff;
+}

--- a/{{cookiecutter.package_name}}/docs/_static/version-switcher.js
+++ b/{{cookiecutter.package_name}}/docs/_static/version-switcher.js
@@ -1,10 +1,14 @@
 (function () {
   "use strict";
 
+  function detectTheme() {
+    if (document.querySelector(".sidebar-drawer")) return "furo";
+    if (document.querySelector(".wy-side-nav-search")) return "rtd";
+    return null;
+  }
+
   function detectCurrentVersion() {
     const segments = window.location.pathname.split("/").filter(Boolean);
-    // GH pages serves at /<repo>/<version>/...
-    // index 0 is the repo name, index 1 is the version slug.
     if (segments.length >= 2) {
       return segments[1];
     }
@@ -28,6 +32,29 @@
     const tail = segments.slice(2).join("/");
     const suffix = tail ? "/" + tail : "/";
     window.location.pathname = "/" + segments[0] + "/" + slug + suffix;
+  }
+
+  function ensureDropdownExists(theme) {
+    if (document.getElementById("cc-version-select")) return;
+    if (theme !== "rtd") return;
+    const target = document.querySelector(".wy-side-nav-search");
+    if (!target) return;
+    const wrap = document.createElement("div");
+    wrap.className = "sidebar-version-selector sidebar-version-selector--rtd";
+    const label = document.createElement("label");
+    label.htmlFor = "cc-version-select";
+    label.className = "sidebar-version-selector__label";
+    label.textContent = "Version";
+    const select = document.createElement("select");
+    select.id = "cc-version-select";
+    select.className = "sidebar-version-selector__select";
+    select.setAttribute("aria-label", "Select documentation version");
+    const placeholder = document.createElement("option");
+    placeholder.value = "";
+    placeholder.textContent = "loading…";
+    select.appendChild(placeholder);
+    wrap.append(label, select);
+    target.appendChild(wrap);
   }
 
   function populate(select, entries, current) {
@@ -62,8 +89,23 @@
     return "https://github.com/" + ghIoMatch[1] + "/" + segments[0];
   }
 
+  function findCopyrightEl() {
+    const selectors = [
+      ".copyright",
+      "footer .copyright",
+      "footer p",
+    ];
+    for (const sel of selectors) {
+      const el = document.querySelector(sel);
+      if (el && /build [a-f0-9]{7,40}/.test(el.textContent)) {
+        return el;
+      }
+    }
+    return null;
+  }
+
   function linkifyBuildHash() {
-    const copyright = document.querySelector(".copyright");
+    const copyright = findCopyrightEl();
     if (!copyright) {
       return;
     }
@@ -92,18 +134,22 @@
     );
   }
 
-  function injectBrandBadge(current) {
-    if (!current) {
-      return;
+  function injectBrandBadge(theme, current) {
+    if (!current) return;
+    let targets = [];
+    if (theme === "furo") {
+      targets = [
+        document.querySelector(".sidebar-brand-text"),
+        document.querySelector(".mobile-header .header-center .brand"),
+      ];
+    } else if (theme === "rtd") {
+      targets = [
+        document.querySelector(".wy-side-nav-search > a"),
+        document.querySelector(".wy-nav-top > a"),
+      ];
     }
-    const targets = [
-      document.querySelector(".sidebar-brand-text"),
-      document.querySelector(".mobile-header .header-center .brand"),
-    ];
     targets.forEach(function (target) {
-      if (!target || target.querySelector(".cc-version-badge")) {
-        return;
-      }
+      if (!target || target.querySelector(".cc-version-badge")) return;
       const badge = document.createElement("span");
       badge.className = "cc-version-badge";
       badge.textContent = current;
@@ -113,10 +159,12 @@
   }
 
   function init() {
-    const select = document.getElementById("cc-version-select");
+    const theme = detectTheme();
     const current = detectCurrentVersion();
-    injectBrandBadge(current);
+    ensureDropdownExists(theme);
+    injectBrandBadge(theme, current);
     linkifyBuildHash();
+    const select = document.getElementById("cc-version-select");
     if (!select) {
       return;
     }

--- a/{{cookiecutter.package_name}}/docs/conf.py
+++ b/{{cookiecutter.package_name}}/docs/conf.py
@@ -90,7 +90,38 @@ html_static_path = ['_static']
 html_context = {
     "display_github": True,
     "github_user": "{{ cookiecutter.project_url.split('/')[-2] }}",
-    "github_repo": "{{ cookiecutter.project_url.split('/')[-1] }}"
+    "github_repo": "{{ cookiecutter.project_url.split('/')[-1] }}",
+    "github_version": "main",
+    "conf_py_path": "/docs/",
+}
+html_css_files = ['version-switcher.css']
+html_js_files = ['version-switcher.js']
+{% endif -%}
+{% if cookiecutter.sphinx_theme == 'pydata-sphinx-theme' -%}
+_pages_base = (
+    f"https://{{ cookiecutter.project_url.split('/')[-2] }}.github.io"
+    f"/{{ cookiecutter.project_url.split('/')[-1] }}"
+)
+html_theme_options = {
+    'use_edit_page_button': True,
+    'switcher': {
+        'json_url': f'{_pages_base}/versions.json',
+        'version_match': os.environ.get('DOCS_VERSION_MATCH', 'latest'),
+    },
+    'navbar_end': ['version-switcher', 'theme-switcher', 'navbar-icon-links'],
+    'icon_links': [
+        {
+            'name': 'GitHub',
+            'url': '{{cookiecutter.project_url}}',
+            'icon': 'fa-brands fa-github',
+        },
+    ],
+}
+html_context = {
+    'github_user': '{{ cookiecutter.project_url.split('/')[-2] }}',
+    'github_repo': '{{ cookiecutter.project_url.split('/')[-1] }}',
+    'github_version': 'main',
+    'doc_path': 'docs',
 }
 {% endif -%}
 {% if cookiecutter.sphinx_theme == 'furo' %}


### PR DESCRIPTION
## Summary
Extends the versioned-docs treatment beyond furo to `sphinx-rtd-theme` and `pydata-sphinx-theme` so generated projects using those themes also get the version switcher, build stamp, and repo links.

Stacks on top of #604.

## sphinx-rtd-theme
- `conf.py`: extend existing rtd `html_context` with `github_version`/`conf_py_path` (enables per-page edit link); register `version-switcher.{js,css}`.
- `version-switcher.js` (template): `detectTheme()` picks `rtd` when `.wy-side-nav-search` exists. `ensureDropdownExists()` injects the dropdown markup into the rtd sidebar via JS (rtd does not use furo's sidebar/ template path convention). `injectBrandBadge()` targets `.wy-side-nav-search > a` and `.wy-nav-top > a`. `linkifyBuildHash()` also probes `<footer p>` for the build stamp.
- Workflow gets a new "Overlay docs theme assets" branch for rtd that copies the JS/CSS and appends a smaller `conf.py` snippet (no `html_sidebars` override).
- CSS: `.sidebar-version-selector--rtd` variant and rtd-tuned badge background.

## pydata-sphinx-theme
- Uses pydata's **native** switcher. No custom JS injection.
- `conf.py`: `html_theme_options.switcher` with `json_url` pointing at `https://<owner>.github.io/<repo>/versions.json` and `version_match` read from `$DOCS_VERSION_MATCH`. Adds `use_edit_page_button`, `icon_links` (GitHub mark), and `navbar_end` includes `version-switcher`.
- No workflow overlay step needed — pydata reads `versions.json` at runtime regardless of build vintage.

## Shared changes
- `versions.json` now includes a `"version"` field (== name) so pydata's switcher can match `version_match` reliably. URLs are absolute (`https://<owner>.github.io/<repo>/<v>/`) which pydata prefers and is harmless for furo's JS (which derives paths from `window.location`).
- New workflow-level `DOCS_VERSION_MATCH` env computed via a short-circuit ternary over `event_name` + `inputs.version`; consumed by pydata's `conf.py` and ignored elsewhere.

Theme-agnostic build-stamp logic and the deploy job are untouched.

## Test plan
- [x] `just tests` — 168/168 pass
- [x] Baked against `furo`, `alabaster`, `sphinx-rtd-theme`, `pydata-sphinx-theme`. YAML parses, `conf.py` compiles, and the gating produces the expected blocks (overlay present only for furo + rtd; pydata switcher only for pydata; etc.)
- [x] `node --check` on the rendered JS
- [ ] After merge: bake a project with each of furo/rtd/pydata, push to GitHub, confirm versioned publishing + version selector work end-to-end

## Stacked on
Depends on #604. Rebase onto main after that merges.
