### PR TITLE
refactor(template): trim sphinx_theme to fully-supported set

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ When you run cookiecutter, you'll be prompted for various configuration options.
 - `supported_python_versions` - Comma-separated list of supported versions
 - `uv_version` - Version of uv to use
 - `tox_version` - Version of tox to use
-- `sphinx_theme` - Documentation theme (select from multiple options)
+- `sphinx_theme` - Documentation theme (furo, sphinx-rtd-theme, or pydata-sphinx-theme)
 
 **Optional Features:**
 - `should_use_direnv` - Include .envrc for direnv (default: y)

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ When you run cookiecutter, you'll be prompted for various configuration options.
 - `supported_python_versions` - Comma-separated list of supported versions
 - `uv_version` - Version of uv to use
 - `tox_version` - Version of tox to use
-- `sphinx_theme` - Documentation theme (furo, sphinx-rtd-theme, or pydata-sphinx-theme)
+- `sphinx_theme` - Documentation theme ([furo](https://pradyunsg.me/furo/), [sphinx-rtd-theme](https://sphinx-rtd-theme.readthedocs.io/), or [pydata-sphinx-theme](https://pydata-sphinx-theme.readthedocs.io/))
 
 **Optional Features:**
 - `should_use_direnv` - Include .envrc for direnv (default: y)

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -16,7 +16,7 @@
   "supported_python_versions": "3.11, 3.12, 3.13, pypy3.11",
   "uv_version": "0.7.3",
   "tox_version": "4.25.0",
-  "sphinx_theme": ["furo", "sphinx-rtd-theme", "sphinx-book-theme", "pydata-sphinx-theme", "sphinx-press-theme", "piccolo-theme", "sphinxawesome-theme", "sphinx-wagtail-theme", "alabaster", "agogo", "bizstyle", "classic", "haiku", "nature", "pyramid", "scrolls", "sphinxdoc", "traditional"],
+  "sphinx_theme": ["furo", "sphinx-rtd-theme", "pydata-sphinx-theme"],
   "should_use_direnv": "y",
   "should_create_author_files": "y",
   "should_install_github_dependabot": "y",

--- a/tests/test_cookiecutter_generation.py
+++ b/tests/test_cookiecutter_generation.py
@@ -846,12 +846,7 @@ def test_with_python_version(
 THIRD_PARTY_SPHINX_THEMES = [
     'furo',
     'sphinx-rtd-theme',
-    'sphinx-book-theme',
     'pydata-sphinx-theme',
-    'sphinx-press-theme',
-    'piccolo-theme',
-    'sphinxawesome-theme',
-    'sphinx-wagtail-theme',
 ]
 
 

--- a/{{cookiecutter.package_name}}/docs/conf.py
+++ b/{{cookiecutter.package_name}}/docs/conf.py
@@ -50,9 +50,6 @@ extensions = [
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
     'myst_parser',
-    {%- if cookiecutter.sphinx_theme == 'sphinx-wagtail-theme' -%}
-    '{{ cookiecutter.sphinx_theme|replace('-', '_') }}'
-    {%- endif %}
 ]
 
 templates_path = ['_templates']
@@ -79,11 +76,7 @@ myst_enable_extensions = [
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-{% if cookiecutter.sphinx_theme == 'sphinx-press-theme' %}
-html_theme = 'press'
-{% else %}
 html_theme = '{{ cookiecutter.sphinx_theme|replace('-', '_') }}'
-{% endif %}
 
 html_static_path = ['_static']
 {% if cookiecutter.sphinx_theme == 'sphinx-rtd-theme' -%}

--- a/{{cookiecutter.package_name}}/pyproject.toml
+++ b/{{cookiecutter.package_name}}/pyproject.toml
@@ -44,18 +44,8 @@ docs = [
     "furo>=2024.8.6,<2025",
     {% elif cookiecutter.sphinx_theme == "sphinx-rtd-theme" %}
     "sphinx-rtd-theme>=2.0.0,<3",
-    {% elif cookiecutter.sphinx_theme == "sphinx-book-theme" %}
-    "sphinx-book-theme>=1.1.2,<2",
     {% elif cookiecutter.sphinx_theme == "pydata-sphinx-theme" %}
     "pydata-sphinx-theme>=0.15.3,<1",
-    {% elif cookiecutter.sphinx_theme == "sphinx-press-theme" %}
-    "sphinx-press-theme>=0.9.1,<1",
-    {% elif cookiecutter.sphinx_theme == "piccolo-theme" %}
-    "piccolo-theme>=0.22.0,<1",
-    {% elif cookiecutter.sphinx_theme == "sphinxawesome-theme" %}
-    "sphinxawesome-theme>=5.1.6,<6",
-    {% elif cookiecutter.sphinx_theme == "sphinx-wagtail-theme" %}
-    "sphinx-wagtail-theme>=6.3.0,<7",
     {% endif %}
 ]
 


### PR DESCRIPTION
## Summary
Trims `sphinx_theme` choices to the three themes that get the full versioned-docs treatment (version selector, badge, per-page edit link, GitHub icon, backfill chrome):

- furo
- sphinx-rtd-theme
- pydata-sphinx-theme

Removed: sphinx-book-theme, sphinx-press-theme, piccolo-theme, sphinxawesome-theme, sphinx-wagtail-theme, alabaster, agogo, bizstyle, classic, haiku, nature, pyramid, scrolls, sphinxdoc, traditional.

## Why
Those 15 themes had no native version switching, and adding custom JS/CSS per theme has diminishing returns. Keeping them as choices implied parity that wasn't there — generated projects on them ended up with only the theme-agnostic build stamp and no switcher.

## Cleanup
- `cookiecutter.json`: trim `sphinx_theme` list to 3.
- `{{cookiecutter.package_name}}/pyproject.toml`: drop the dropped themes' dependency branches.
- `{{cookiecutter.package_name}}/docs/conf.py`: drop the wagtail-extension inclusion (only wagtail needed it) and the `sphinx-press-theme` `html_theme = 'press'` override.
- `tests/test_cookiecutter_generation.py`: trim `THIRD_PARTY_SPHINX_THEMES` to the kept three.
- `README.md`: name the three supported themes explicitly.

## Test plan
- [x] `just tests` — 163/163 pass (was 168; the 5 dropped tests are the parametrized theme tests we removed)
- [x] Hand-verified bake for each kept theme produces valid `docs.yml`, `conf.py`, and `pyproject.toml` containing the right theme dependency
