### PR TITLE
chore: tidy stale TODO + breaking-label resolver

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -25,9 +25,11 @@ categories:
 
 
 version-resolver:
-  minor:
+  major:
     labels:
       - 'breaking'
+  minor:
+    labels:
       - 'feature'
   patch:
     labels:

--- a/README.md
+++ b/README.md
@@ -249,9 +249,9 @@ See the [open issues](https://github.com/ryankanno/cookiecutter-py/issues) for a
 - [ ] add hypothesis example to template
 - [ ] add licenses
 - [ ] add typeguard
-- [ ] version releases
-- [ ] update docs
-- [ ] add publish docs workflow
+- [X] version releases
+- [X] add publish docs workflow
+- [X] update docs
 - [X] include cookiecutter var descriptions
 - [X] update default/initial template doc structure
 - [X] investigate uv


### PR DESCRIPTION
## Summary
Cleanup pass on three items called out in the recent project audit.

### release-drafter.yml
Promote the `breaking` label from `minor` to `major` in the version-resolver. Previously, cutting `2.0.0` had to be done manually because the drafter would only ever draft minor bumps even with a `breaking` PR merged. Future breaking PRs will now bump the major.

### README.md
Tick off three TODO items that the recent version-docs work (#597-#606) actually delivered:

- `version releases`
- `add publish docs workflow`
- `update docs`

### Stale worktrees (already done locally)
Removed four local-only worktrees that had been sitting in `.worktrees/` for 4-5 weeks:

- `uv-0.11.7` (no commits ahead)
- `fix-clean-build-egg-info-prune`
- `fix-template-ruff-bound`
- `test-post-gen-hooks`

The underlying branches were preserved as recovery points — `git worktree remove --force` only nuked the working directories, not the refs. None were pushed to the remote, so this change is local-only and not reflected in this PR diff. Listed here for visibility.

## Test plan
- [x] Pre-commit hooks pass
- [ ] After merge: next `breaking`-labeled PR drafts a major bump (verify on the next release draft GitHub Actions run)
